### PR TITLE
Fix for reason phrase with spaces

### DIFF
--- a/lib/Buzz/Message/Response.php
+++ b/lib/Buzz/Message/Response.php
@@ -40,7 +40,7 @@ class Response extends AbstractMessage
     public function getReasonPhrase()
     {
         if (isset($this->headers[0])) {
-            list($httpVersion, $statusCode, $reasonPhrase) = explode(' ', $this->headers[0]);
+            list($httpVersion, $statusCode, $reasonPhrase) = explode(' ', $this->headers[0], 3);
 
             return $reasonPhrase;
         }

--- a/test/Buzz/Message/ResponseTest.php
+++ b/test/Buzz/Message/ResponseTest.php
@@ -32,8 +32,8 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($response->getReasonPhrase(), null);
 
-        $response->addHeader('1.0 200 OK');
+        $response->addHeader('1.0 404 Not Found');
 
-        $this->assertEquals($response->getReasonPhrase(), 'OK');
+        $this->assertEquals($response->getReasonPhrase(), 'Not Found');
     }
 }


### PR DESCRIPTION
e.g. 404 Not Found
