### PR TITLE
Buzz\Message\Response::getReasonPhrase() returns only first word

### DIFF
--- a/lib/Buzz/Message/Response.php
+++ b/lib/Buzz/Message/Response.php
@@ -12,7 +12,7 @@ class Response extends AbstractMessage
     public function getProtocolVersion()
     {
         if (isset($this->headers[0])) {
-            list($httpVersion, $statusCode, $reasonPhrase) = explode(' ', $this->headers[0]);
+            list($httpVersion) = explode(' ', $this->headers[0]);
 
             return (float) $httpVersion;
         }
@@ -26,7 +26,7 @@ class Response extends AbstractMessage
     public function getStatusCode()
     {
         if (isset($this->headers[0])) {
-            list($httpVersion, $statusCode, $reasonPhrase) = explode(' ', $this->headers[0]);
+            list(, $statusCode) = explode(' ', $this->headers[0]);
 
             return (integer) $statusCode;
         }
@@ -40,9 +40,7 @@ class Response extends AbstractMessage
     public function getReasonPhrase()
     {
         if (isset($this->headers[0])) {
-            list($httpVersion, $statusCode, $reasonPhrase) = explode(' ', $this->headers[0]);
-
-            return $reasonPhrase;
+            return substr($this->headers[0], strpos($this->headers[0], ' ', strpos($this->headers[0], ' ') + 1) + 1);
         }
     }
 

--- a/test/Buzz/Message/ResponseTest.php
+++ b/test/Buzz/Message/ResponseTest.php
@@ -36,4 +36,15 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($response->getReasonPhrase(), 'OK');
     }
+
+    public function testGetReasonPhraseReturnsTheReasonPhraseMultiword()
+    {
+        $response = new Response();
+
+        $this->assertEquals($response->getReasonPhrase(), null);
+
+        $response->addHeader('1.0 500 Internal Server Error');
+
+        $this->assertEquals($response->getReasonPhrase(), 'Internal Server Error');
+    }
 }


### PR DESCRIPTION
Added a test and also removed unneeded variables from other two methods.
