### PR TITLE
Alteration to the Curl client to ensure that operations are performed on a curl resource

### DIFF
--- a/lib/Buzz/Client/Curl.php
+++ b/lib/Buzz/Client/Curl.php
@@ -72,6 +72,10 @@ class Curl implements ClientInterface
 
     public function send(Message\Request $request, Message\Response $response)
     {
+        if (false === is_resource($this->curl))
+        {
+            $this->curl = static::createCurlHandle();
+        }
         $this->prepare($request, $response, $this->curl);
         $response->fromString(static::getLastResponse(curl_exec($this->curl)));
     }
@@ -87,6 +91,9 @@ class Curl implements ClientInterface
 
     public function __destruct()
     {
-        curl_close($this->curl);
+        if (is_resource($this->curl))
+        {
+            curl_close($this->curl);
+        }
     }
 }


### PR DESCRIPTION
I've been experiencing issues when using Goutte through Behat that occasionally the curl resource goes away before the Curl client has the opportunity to send messages on it.

Assuming that ->send(..) method calls are still when issued, my changes perform a type check on $this->curl - if it's not a valid resource, $this->curl is reinitialized.

There is also a check on the destructor; if $this->curl is no longer a valid curl resource then the destructor (a) is redundant and (b) throws a fatal error.
