### PR TITLE
Quick fix for cookie headers

### DIFF
--- a/lib/Buzz/Cookie/Jar.php
+++ b/lib/Buzz/Cookie/Jar.php
@@ -43,6 +43,7 @@ class Jar
                 $request->addHeader($cookie->toCookieHeader());
             }
         }
+        $request->groupHeader('Cookie');
     }
 
     /**

--- a/lib/Buzz/Message/AbstractMessage.php
+++ b/lib/Buzz/Message/AbstractMessage.php
@@ -91,6 +91,23 @@ abstract class AbstractMessage
         return $document;
     }
 
+    public function groupHeader($name, $glue="; "){
+        $needle = $name.':';
+
+        $values = array();
+        foreach ($this->getHeaders() as $i=>$header) {
+            if (0 === strpos($header, $needle)) {
+                $values[] = trim(substr($header, strlen($needle)));
+                unset($this->headers[$i]);
+            }
+        }
+
+        if (count($values) > 0) {
+            $header = $needle . implode($glue, $values);
+            $this->addHeader($header);
+        }
+    }
+
     public function setHeaders(array $headers)
     {
         $this->headers = $headers;


### PR DESCRIPTION
Hi,

I have been using Buzz to test a web app which required multiple cookie headers, the cookies where not being correctly interpreted. I found that Buzz was setting each cookie as a separate header so I have added a method to AbstractMessage.php to group cookies with the same name together. This corrected the issue.

Regards,

Ed
