### PR TITLE
Made FileGetContents extend AbstractStream

### DIFF
--- a/lib/Buzz/Client/FileGetContents.php
+++ b/lib/Buzz/Client/FileGetContents.php
@@ -5,7 +5,7 @@ namespace Buzz\Client;
 use Buzz\Cookie;
 use Buzz\Message;
 
-class FileGetContents extends AbstractClient implements ClientInterface
+class FileGetContents extends AbstractStream implements ClientInterface
 {
     protected $cookieJar;
 


### PR DESCRIPTION
Made FileGetContents extend AbstractStream so still have access to the getStreamContextArray method. Looks like this was removed in this refactoring:

https://github.com/kriswallsmith/Buzz/commit/d5a2ce2554f7737b259b9d9e4fe26fe03ccceb91 

So FileGetContents currently doesnt work at all.
