### PR TITLE
[Tests] Use proper argument order

### DIFF
--- a/test/Buzz/BrowserTest.php
+++ b/test/Buzz/BrowserTest.php
@@ -17,7 +17,7 @@ class BrowserTest extends \PHPUnit_Framework_TestCase
     public function testGetReturnsAResponse()
     {
         $this->browser->getClient()->sendToQueue(new Message\Response());
-        $this->assertTrue($this->browser->get('http://www.google.com') instanceof Message\Response);
+        $this->assertInstanceOf('Buzz\\Message\\Response', $this->browser->get('http://www.google.com'));
     }
 
     public function testGetDomReturnsADomDocument()

--- a/test/Buzz/Client/AbstractStreamTest.php
+++ b/test/Buzz/Client/AbstractStreamTest.php
@@ -31,6 +31,6 @@ class AbstractStreamTest extends \PHPUnit_Framework_TestCase
             'timeout'          => 10,
         ));
 
-        $this->assertEquals($client->getStreamContextArray($request), $expected);
+        $this->assertEquals($expected, $client->getStreamContextArray($request));
     }
 }

--- a/test/Buzz/Client/Mock/FIFOTest.php
+++ b/test/Buzz/Client/Mock/FIFOTest.php
@@ -16,16 +16,16 @@ class FIFOTest extends \PHPUnit_Framework_TestCase
         $client->setQueue(array($response));
         $client->sendToQueue($response);
 
-        $this->assertEquals(count($client->getQueue()), 2);
+        $this->assertEquals(2, count($client->getQueue()));
 
         $request = new Message\Request();
         $response = new Message\Response();
         $client->send($request, $response);
 
-        $this->assertEquals(count($client->getQueue()), 1);
+        $this->assertEquals(1, count($client->getQueue()));
 
-        $this->assertEquals($response->getHeaders(), array('HTTP/1.0 200 OK'));
-        $this->assertEquals($response->getContent(), 'Hello World!');
+        $this->assertEquals(array('HTTP/1.0 200 OK'), $response->getHeaders());
+        $this->assertEquals('Hello World!', $response->getContent());
     }
 
     /**

--- a/test/Buzz/Client/Mock/LIFOTest.php
+++ b/test/Buzz/Client/Mock/LIFOTest.php
@@ -22,6 +22,6 @@ class LIFOTest extends \PHPUnit_Framework_TestCase
         $response = new Message\Response();
         $client->send($request, $response);
 
-        $this->assertEquals($response->getContent(), 'last');
+        $this->assertEquals('last', $response->getContent());
     }
 }

--- a/test/Buzz/Cookie/CookieTest.php
+++ b/test/Buzz/Cookie/CookieTest.php
@@ -11,14 +11,14 @@ class CookieTest extends \PHPUnit_Framework_TestCase
         $cookie = new Cookie();
         $cookie->fromSetCookieHeader('SESSION=asdf; expires='.date('r', strtotime('2000-01-01 00:00:00')).'; path=/; domain=.example.com; secure', 'www.example.com');
 
-        $this->assertEquals($cookie->getName(), 'SESSION');
-        $this->assertEquals($cookie->getValue(), 'asdf');
-        $this->assertEquals($cookie->getAttributes(), array(
+        $this->assertEquals('SESSION', $cookie->getName());
+        $this->assertEquals('asdf', $cookie->getValue());
+        $this->assertEquals(array(
             'expires' => date('r', strtotime('2000-01-01 00:00:00')),
             'path'    => '/',
             'domain'  => '.example.com',
             'secure'  => null,
-        ));
+        ), $cookie->getAttributes());
     }
 
     public function testFromSetCookieHeaderFallsBackToIssuingDomain()
@@ -26,7 +26,7 @@ class CookieTest extends \PHPUnit_Framework_TestCase
         $cookie = new Cookie();
         $cookie->fromSetCookieHeader('SESSION=asdf', 'example.com');
 
-        $this->assertEquals($cookie->getAttribute(Cookie::ATTR_DOMAIN), 'example.com');
+        $this->assertEquals('example.com', $cookie->getAttribute(Cookie::ATTR_DOMAIN));
     }
 
     public function testToCookieHeaderFormatsACookieHeader()
@@ -35,7 +35,7 @@ class CookieTest extends \PHPUnit_Framework_TestCase
         $cookie->setName('SESSION');
         $cookie->setValue('asdf');
 
-        $this->assertEquals($cookie->toCookieHeader(), 'Cookie: SESSION=asdf');
+        $this->assertEquals('Cookie: SESSION=asdf', $cookie->toCookieHeader());
     }
 
     public function testMatchesDomainMatchesSimpleDomains()

--- a/test/Buzz/Cookie/JarTest.php
+++ b/test/Buzz/Cookie/JarTest.php
@@ -20,9 +20,9 @@ class JarTest extends \PHPUnit_Framework_TestCase
 
         $cookies = $jar->getCookies();
 
-        $this->assertEquals(count($cookies), 2);
+        $this->assertEquals(2, count($cookies));
         foreach ($cookies as $cookie) {
-            $this->assertEquals($cookie->getAttribute(Cookie::ATTR_DOMAIN), 'www.example.com');
+            $this->assertEquals('www.example.com', $cookie->getAttribute(Cookie::ATTR_DOMAIN));
             $this->assertTrue(in_array($cookie->getName(), array('SESSION1', 'SESSION2')));
         }
     }
@@ -41,7 +41,7 @@ class JarTest extends \PHPUnit_Framework_TestCase
         $jar->setCookies(array($cookie));
         $jar->addCookieHeaders($request);
 
-        $this->assertEquals($request->getHeader('Cookie'), 'SESSION=asdf');
+        $this->assertEquals('SESSION=asdf', $request->getHeader('Cookie'));
     }
 
     public function testClearExpiredCookiesRemovesExpiredCookies()
@@ -55,7 +55,7 @@ class JarTest extends \PHPUnit_Framework_TestCase
         $jar->addCookie($cookie);
         $jar->clearExpiredCookies();
 
-        $this->assertEquals(count($jar->getCookies()), 0);
+        $this->assertEquals(0, count($jar->getCookies()));
 
         $cookie = new Cookie();
         $cookie->setName('SESSION');
@@ -66,6 +66,6 @@ class JarTest extends \PHPUnit_Framework_TestCase
         $jar->addCookie($cookie);
         $jar->clearExpiredCookies();
 
-        $this->assertEquals(count($jar->getCookies()), 0);
+        $this->assertEquals(0, count($jar->getCookies()));
     }
 }

--- a/test/Buzz/History/JournalTest.php
+++ b/test/Buzz/History/JournalTest.php
@@ -31,6 +31,17 @@ class JournalTest extends \PHPUnit_Framework_TestCase
         $this->response3->setContent('response3');
     }
 
+    public function tearDown()
+    {
+        $this->request1 = null;
+        $this->request2 = null;
+        $this->request3 = null;
+
+        $this->response1 = null;
+        $this->response2 = null;
+        $this->response3 = null;
+    }
+
     public function testRecordEnforcesLimit()
     {
         $journal = new Journal();
@@ -40,7 +51,7 @@ class JournalTest extends \PHPUnit_Framework_TestCase
         $journal->record($this->request2, $this->response2);
         $journal->record($this->request3, $this->response3);
 
-        $this->assertEquals(count($journal), 2);
+        $this->assertEquals(2, count($journal));
     }
 
     public function testGetLastReturnsTheLastEntry()
@@ -50,7 +61,7 @@ class JournalTest extends \PHPUnit_Framework_TestCase
         $journal->record($this->request1, $this->response1);
         $journal->record($this->request2, $this->response2);
 
-        $this->assertEquals($journal->getLast()->getRequest(), $this->request2);
+        $this->assertEquals($this->request2, $journal->getLast()->getRequest());
 
         return $journal;
     }
@@ -60,7 +71,7 @@ class JournalTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetLastRequestReturnsTheLastRequest(Journal $journal)
     {
-        $this->assertEquals($journal->getLastRequest(), $this->request2);
+        $this->assertEquals($this->request2, $journal->getLastRequest());
     }
 
     /**
@@ -68,7 +79,7 @@ class JournalTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetLastResponseReturnsTheLastResponse(Journal $journal)
     {
-        $this->assertEquals($journal->getLastResponse(), $this->response2);
+        $this->assertEquals($this->response2, $journal->getLastResponse());
     }
 
     /**
@@ -77,7 +88,7 @@ class JournalTest extends \PHPUnit_Framework_TestCase
     public function testClearRemovesEntries(Journal $journal)
     {
         $journal->clear();
-        $this->assertEquals(count($journal), 0);
+        $this->assertEquals(0, count($journal));
     }
 
     /**
@@ -89,8 +100,8 @@ class JournalTest extends \PHPUnit_Framework_TestCase
         $responses = array($this->response2, $this->response1);
 
         foreach ($journal as $index => $entry) {
-            $this->assertEquals($entry->getRequest(), $requests[$index]);
-            $this->assertEquals($entry->getResponse(), $responses[$index]);
+            $this->assertEquals($requests[$index], $entry->getRequest());
+            $this->assertEquals($responses[$index], $entry->getResponse());
         }
     }
 }

--- a/test/Buzz/Message/AbstractMessageTest.php
+++ b/test/Buzz/Message/AbstractMessageTest.php
@@ -14,9 +14,9 @@ class AbstractMessageTest extends \PHPUnit_Framework_TestCase
         $message->addHeader('X-My-Header: foo');
         $message->addHeader('X-My-Header: bar');
 
-        $this->assertEquals($message->getHeader('X-My-Header'), 'foo'.PHP_EOL.'bar');
-        $this->assertEquals($message->getHeader('X-My-Header', ','), 'foo,bar');
-        $this->assertEquals($message->getHeader('X-My-Header', false), array('foo', 'bar'));
+        $this->assertEquals('foo'.PHP_EOL.'bar', $message->getHeader('X-My-Header'));
+        $this->assertEquals('foo,bar', $message->getHeader('X-My-Header', ','));
+        $this->assertEquals(array('foo', 'bar'), $message->getHeader('X-My-Header', false));
     }
 
     public function testGetHeaderReturnsNullIfHeaderDoesNotExist()
@@ -39,7 +39,7 @@ Foo: Bar
 
 EOF;
 
-        $this->assertEquals((string) $message, $expected);
+        $this->assertEquals($expected, (string) $message);
     }
 
     public function testGetHeaderAttributesReturnsHeaderAttributes()
@@ -47,6 +47,6 @@ EOF;
         $message = new Message();
         $message->addHeader('Content-Type: text/xml; charset=utf8');
 
-        $this->assertEquals($message->getHeaderAttribute('Content-Type', 'charset'), 'utf8');
+        $this->assertEquals('utf8', $message->getHeaderAttribute('Content-Type', 'charset'));
     }
 }

--- a/test/Buzz/Message/RequestTest.php
+++ b/test/Buzz/Message/RequestTest.php
@@ -8,9 +8,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $request = new Request('HEAD', '/resource/123', 'http://example.com');
 
-        $this->assertEquals($request->getMethod(), 'HEAD');
-        $this->assertEquals($request->getResource(), '/resource/123');
-        $this->assertEquals($request->getHost(), 'http://example.com');
+        $this->assertEquals('HEAD', $request->getMethod());
+        $this->assertEquals('/resource/123', $request->getResource());
+        $this->assertEquals('http://example.com', $request->getHost());
     }
 
     public function testGetUrlFormatsAUrl()
@@ -19,7 +19,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request->setHost('http://example.com');
         $request->setResource('/resource/123');
 
-        $this->assertEquals($request->getUrl(), 'http://example.com/resource/123');
+        $this->assertEquals('http://example.com/resource/123', $request->getUrl());
     }
 
     public function testFromUrlSetsRequestValues()
@@ -27,8 +27,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $request->fromUrl('http://example.com/resource/123?foo=bar#foobar');
 
-        $this->assertEquals($request->getHost(), 'http://example.com');
-        $this->assertEquals($request->getResource(), '/resource/123?foo=bar');
+        $this->assertEquals('http://example.com', $request->getHost());
+        $this->assertEquals('/resource/123?foo=bar', $request->getResource());
     }
 
     public function testFromUrlSetsADefaultResource()
@@ -36,12 +36,12 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $request->fromUrl('http://example.com');
 
-        $this->assertEquals($request->getResource(), '/');
+        $this->assertEquals('/', $request->getResource());
 
         $request = new Request();
         $request->fromUrl('http://example.com?foo=bar');
 
-        $this->assertEquals($request->getResource(), '/?foo=bar');
+        $this->assertEquals('/?foo=bar', $request->getResource());
     }
 
     public function testFromUrlSetsADefaultScheme()
@@ -49,8 +49,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $request->fromUrl('example.com/foo/bar');
 
-        $this->assertEquals($request->getHost(), 'http://example.com');
-        $this->assertEquals($request->getResource(), '/foo/bar');
+        $this->assertEquals('http://example.com', $request->getHost());
+        $this->assertEquals('/foo/bar', $request->getResource());
     }
 
     public function testFromUrlLeaveHostEmptyIfNoneIsProvided()
@@ -66,8 +66,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $request->fromUrl('http://localhost:3000/foo');
 
-        $this->assertEquals($request->getHost(), 'http://localhost:3000');
-        $this->assertEquals($request->getResource(), '/foo');
+        $this->assertEquals('http://localhost:3000', $request->getHost());
+        $this->assertEquals('/foo', $request->getResource());
     }
 
     public function testFromUrlRejectsInvalidUrl()
@@ -104,7 +104,7 @@ foo=bar&bar=baz
 
 EOF;
 
-        $this->assertEquals((string) $request, $expected);
+        $this->assertEquals($expected, (string) $request);
     }
 
     public function testMethodIsAlwaysUppercased()

--- a/test/Buzz/Message/ResponseTest.php
+++ b/test/Buzz/Message/ResponseTest.php
@@ -8,22 +8,22 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     {
         $response = new Response();
 
-        $this->assertEquals($response->getProtocolVersion(), null);
+        $this->assertNull($response->getProtocolVersion());
 
         $response->addHeader('1.0 200 OK');
 
-        $this->assertEquals($response->getProtocolVersion(), 1.0);
+        $this->assertEquals(1.0, $response->getProtocolVersion());
     }
 
     public function testGetStatusCodeReturnsTheStatusCode()
     {
         $response = new Response();
 
-        $this->assertEquals($response->getStatusCode(), null);
+        $this->assertNull($response->getStatusCode());
 
         $response->addHeader('1.0 200 OK');
 
-        $this->assertEquals($response->getStatusCode(), 200);
+        $this->assertEquals(200, $response->getStatusCode());
     }
 
     public function testGetReasonPhraseReturnsTheReasonPhrase()
@@ -34,17 +34,17 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $response->addHeader('1.0 200 OK');
 
-        $this->assertEquals($response->getReasonPhrase(), 'OK');
+        $this->assertEquals('OK', $response->getReasonPhrase());
     }
 
     public function testGetReasonPhraseReturnsAMultiwordReasonPhrase()
     {
         $response = new Response();
 
-        $this->assertEquals($response->getReasonPhrase(), null);
+        $this->assertNull($response->getReasonPhrase());
 
         $response->addHeader('1.0 500 Internal Server Error');
 
-        $this->assertEquals($response->getReasonPhrase(), 'Internal Server Error');
+        $this->assertEquals('Internal Server Error', $response->getReasonPhrase());
     }
 }


### PR DESCRIPTION
Use proper argument order to skip confusing PHPUnit messages when tests fail. Also changed some tests to use proper assertions.
