### PR TITLE
Added a check as fileinfo is not enabled by default on Windows

### DIFF
--- a/lib/Buzz/Message/FormUpload.php
+++ b/lib/Buzz/Message/FormUpload.php
@@ -105,7 +105,7 @@ class FormUpload extends AbstractMessage
 
     private function detectContentType()
     {
-        if (!class_exists('finfo')) {
+        if (!class_exists('finfo', false)) {
             return false;
         }
 


### PR DESCRIPTION
I return `false` when fileinfo is not available as it is also the value returned by finfo when it is unable to find the content type
