### PR TITLE
DELETE verb should also set contents in the request body

### DIFF
--- a/lib/Buzz/Client/Curl.php
+++ b/lib/Buzz/Client/Curl.php
@@ -40,6 +40,7 @@ class Curl extends AbstractClient implements ClientInterface
 
             case Message\Request::METHOD_POST:
             case Message\Request::METHOD_PUT:
+            case Message\Request::METHOD_DELETE:
                 $options[CURLOPT_POSTFIELDS] = $fields = self::getPostFields($request);
 
                 // remove the content-type header


### PR DESCRIPTION
Altough not 100% clear whether DELETE accepts content in it the body of the request or not, the buzz Browser class definition allows for content to be sent, but that content is never sent in the Curl client.

Some nice reference:

http://stackoverflow.com/questions/299628/is-an-entity-body-allowed-for-an-http-delete-request
