### PR TITLE
Provide common API for setting "verify peer" functionality across clients.

### DIFF
--- a/lib/Buzz/Client/AbstractClient.php
+++ b/lib/Buzz/Client/AbstractClient.php
@@ -9,6 +9,7 @@ abstract class AbstractClient
     protected $ignoreErrors = true;
     protected $maxRedirects = 5;
     protected $timeout = 5;
+    protected $verifyPeer = false;
 
     public function setIgnoreErrors($ignoreErrors)
     {
@@ -38,5 +39,15 @@ abstract class AbstractClient
     public function getTimeout()
     {
         return $this->timeout;
+    }
+
+    public function setVerifyPeer($verifyPeer)
+    {
+        $this->verifyPeer = $verifyPeer;
+    }
+
+    public function getVerifyPeer()
+    {
+        return $this->verifyPeer;
     }
 }

--- a/lib/Buzz/Client/AbstractStream.php
+++ b/lib/Buzz/Client/AbstractStream.php
@@ -15,17 +15,22 @@ abstract class AbstractStream extends AbstractClient
      */
     public function getStreamContextArray(Message\Request $request)
     {
-        return array('http' => array(
-            // values from the request
-            'method'           => $request->getMethod(),
-            'header'           => implode("\r\n", $request->getHeaders()),
-            'content'          => $request->getContent(),
-            'protocol_version' => $request->getProtocolVersion(),
+        return array(
+            'http' => array(
+                // values from the request
+                'method'           => $request->getMethod(),
+                'header'           => implode("\r\n", $request->getHeaders()),
+                'content'          => $request->getContent(),
+                'protocol_version' => $request->getProtocolVersion(),
 
-            // values from the current client
-            'ignore_errors'    => $this->getIgnoreErrors(),
-            'max_redirects'    => $this->getMaxRedirects(),
-            'timeout'          => $this->getTimeout(),
-        ));
+                // values from the current client
+                'ignore_errors'    => $this->getIgnoreErrors(),
+                'max_redirects'    => $this->getMaxRedirects(),
+                'timeout'          => $this->getTimeout(),
+            ),
+            'ssl' => array(
+                'verify_peer'      => $this->getVerifyPeer(),
+            ),
+        );
     }
 }

--- a/lib/Buzz/Client/Curl.php
+++ b/lib/Buzz/Client/Curl.php
@@ -138,6 +138,7 @@ class Curl extends AbstractClient implements ClientInterface
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, 0 < $this->maxRedirects);
         curl_setopt($curl, CURLOPT_MAXREDIRS, $this->maxRedirects);
         curl_setopt($curl, CURLOPT_FAILONERROR, !$this->ignoreErrors);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->verifyPeer);
     }
 
     public function __destruct()

--- a/test/Buzz/Test/Client/AbstractStreamTest.php
+++ b/test/Buzz/Test/Client/AbstractStreamTest.php
@@ -22,16 +22,25 @@ class AbstractStreamTest extends \PHPUnit_Framework_TestCase
         $client->setMaxRedirects(5);
         $client->setIgnoreErrors(false);
         $client->setTimeout(10);
-        $expected = array('http' => array(
-            'method'           => 'POST',
-            'header'           => "Content-Type: application/x-www-form-urlencoded\r\nContent-Length: 15",
-            'content'          => 'foo=bar&bar=baz',
-            'protocol_version' => 1.0,
-            'ignore_errors'    => false,
-            'max_redirects'    => 5,
-            'timeout'          => 10,
-        ));
+        $expected = array(
+            'http' => array(
+                'method'           => 'POST',
+                'header'           => "Content-Type: application/x-www-form-urlencoded\r\nContent-Length: 15",
+                'content'          => 'foo=bar&bar=baz',
+                'protocol_version' => 1.0,
+                'ignore_errors'    => false,
+                'max_redirects'    => 5,
+                'timeout'          => 10,
+            ),
+            'ssl' => array(
+                'verify_peer'      => false,
+            ),
+        );
 
+        $this->assertEquals($expected, $client->getStreamContextArray($request));
+
+        $client->setVerifyPeer(true);
+        $expected['ssl']['verify_peer'] = true;
         $this->assertEquals($expected, $client->getStreamContextArray($request));
     }
 }


### PR DESCRIPTION
Both Curl and stream based backends support a configuration option to validate a certificate before communicating over HTTPS. This change standardizes the behavior to _not_ validate certificates by default (this is the default behavior for the stream based backend) and provides a facility to change this at runtime if needed.

BC issues: Anyone who was relying on the Curl client's default behavior of failing on invalid certificate will have no warning that they are now able to connect to a site with an invalid certificate.

Coding standards: I wasn't sure what to do with the big context arrays as this involved adding a new key. I'm pretty sure this will conflict with the proxy PR that is in the queue. I'm happy to change this to another style. :)
