### PR TITLE
Fixes new proxy code

### DIFF
--- a/lib/Buzz/Client/AbstractClient.php
+++ b/lib/Buzz/Client/AbstractClient.php
@@ -3,6 +3,7 @@
 namespace Buzz\Client;
 
 use Buzz\Message;
+use Buzz\Util;
 
 abstract class AbstractClient
 {
@@ -10,6 +11,7 @@ abstract class AbstractClient
     protected $maxRedirects = 5;
     protected $timeout = 5;
     protected $verifyPeer = true;
+    protected $proxy;
 
     public function setIgnoreErrors($ignoreErrors)
     {
@@ -49,5 +51,15 @@ abstract class AbstractClient
     public function getVerifyPeer()
     {
         return $this->verifyPeer;
+    }
+
+    public function setProxy(Util\Url $proxy)
+    {
+        $this->proxy = $proxy;
+    }
+
+    public function getProxy()
+    {
+        return $this->proxy;
     }
 }

--- a/lib/Buzz/Client/AbstractStream.php
+++ b/lib/Buzz/Client/AbstractStream.php
@@ -15,7 +15,7 @@ abstract class AbstractStream extends AbstractClient
      */
     public function getStreamContextArray(Message\Request $request)
     {
-        return array(
+        $options = array(
             'http' => array(
                 // values from the request
                 'method'           => $request->getMethod(),
@@ -32,5 +32,12 @@ abstract class AbstractStream extends AbstractClient
                 'verify_peer'      => $this->getVerifyPeer(),
             ),
         );
+
+        if ($proxy = $this->getProxy()) {
+            $options['http']['proxy'] = $proxy->getUrl();
+            $options['http']['request_fulluri'] = true;
+        }
+
+        return $options;
     }
 }

--- a/lib/Buzz/Client/AbstractStream.php
+++ b/lib/Buzz/Client/AbstractStream.php
@@ -62,7 +62,7 @@ abstract class AbstractStream extends AbstractClient
         // port it matched the scheme default.
         $proxy = $this->proxy->getHostname() . ':' . $this->proxy->getPort();
 
-        if ('htttps' === $this->proxy->getScheme()) {
+        if ('https' === $this->proxy->getScheme()) {
             if (!extension_loaded('openssl')) {
                 throw new \RuntimeException('You must enable the openssl extension to use a proxy over https');
             }

--- a/lib/Buzz/Client/AbstractStream.php
+++ b/lib/Buzz/Client/AbstractStream.php
@@ -33,11 +33,42 @@ abstract class AbstractStream extends AbstractClient
             ),
         );
 
-        if ($proxy = $this->getProxy()) {
-            $options['http']['proxy'] = $proxy->getUrl();
+        if ($proxyOption = $this->getProxyOption()) {
+            $options['http']['proxy'] = $proxyOption;
             $options['http']['request_fulluri'] = true;
         }
 
         return $options;
+    }
+
+    protected function getProxyOption()
+    {
+        if (!$this->getProxy()) {
+            return null;
+        }
+
+        if ($user = $this->getProxy()->getUser()) {
+            if ($password = $this->getProxy()->getPassword()) {
+                $proxyAuth = $user.':'.$password.'@';
+            } else {
+                $proxyAuth = $user.'@';
+            }
+        } else {
+            $proxyAuth = '';
+        }
+
+        // We actually need the port otherwise stream croaks. Had initially
+        // tried proxy->getHost() and it did not work since it removed the
+        // port it matched the scheme default.
+        $proxy = $this->proxy->getHostname() . ':' . $this->proxy->getPort();
+
+        if ('htttps' === $this->proxy->getScheme()) {
+            if (!extension_loaded('openssl')) {
+                throw new \RuntimeException('You must enable the openssl extension to use a proxy over https');
+            }
+            return 'ssl://'.$proxyAuth.$proxy;
+        }
+
+        return 'tcp://'.$proxyAuth.$proxy;
     }
 }

--- a/lib/Buzz/Client/Curl.php
+++ b/lib/Buzz/Client/Curl.php
@@ -142,10 +142,8 @@ class Curl extends AbstractClient implements ClientInterface
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->verifyPeer);
 
         if ($proxy = $this->getProxy()) {
-            // We actually need the port otherwise curl croaks. Had initially
-            // tried proxy->getHost() and it did not work since it removed the
-            // port it matched the scheme default.
-            curl_setopt($curl, CURLOPT_PROXY, $proxy->getHost().':'.$proxy->getPort());
+            curl_setopt($curl, CURLOPT_PROXY, $proxy->getHostname());
+            curl_setopt($curl, CURLOPT_PROXYPORT, $proxy->getPort());
             if ($user = $proxy->getUser()) {
                 curl_setopt($curl, CURLOPT_PROXYUSERPWD, $user.':'.$proxy->getPassword());
             } else {

--- a/lib/Buzz/Client/Curl.php
+++ b/lib/Buzz/Client/Curl.php
@@ -140,6 +140,18 @@ class Curl extends AbstractClient implements ClientInterface
         curl_setopt($curl, CURLOPT_MAXREDIRS, $this->maxRedirects);
         curl_setopt($curl, CURLOPT_FAILONERROR, !$this->ignoreErrors);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->verifyPeer);
+
+        if ($proxy = $this->getProxy()) {
+            curl_setopt($curl, CURLOPT_PROXY, $proxy->getHostname());
+            if ($user = $proxy->getUser()) {
+                curl_setopt($curl, CURLOPT_PROXYUSERPWD, $user.':'.$proxy->getPassword());
+            } else {
+                curl_setopt($curl, CURLOPT_PROXYUSERPWD, null);
+            }
+        } else {
+            curl_setopt($curl, CURLOPT_PROXY, null);
+            curl_setopt($curl, CURLOPT_PROXYUSERPWD, null);
+        }
     }
 
     public function __destruct()

--- a/lib/Buzz/Client/Curl.php
+++ b/lib/Buzz/Client/Curl.php
@@ -142,7 +142,10 @@ class Curl extends AbstractClient implements ClientInterface
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->verifyPeer);
 
         if ($proxy = $this->getProxy()) {
-            curl_setopt($curl, CURLOPT_PROXY, $proxy->getHostname());
+            // We actually need the port otherwise curl croaks. Had initially
+            // tried proxy->getHost() and it did not work since it removed the
+            // port it matched the scheme default.
+            curl_setopt($curl, CURLOPT_PROXY, $proxy->getHost().':'.$proxy->getPort());
             if ($user = $proxy->getUser()) {
                 curl_setopt($curl, CURLOPT_PROXYUSERPWD, $user.':'.$proxy->getPassword());
             } else {

--- a/lib/Buzz/Util/Url.php
+++ b/lib/Buzz/Util/Url.php
@@ -29,6 +29,17 @@ class Url
             $components['path'] = '/'.$path;
         }
 
+        if (isset($components['scheme']) && !isset($components['port'])) {
+            switch($components['scheme']) {
+                case 'http':
+                    $components['port'] = 80;
+                    break;
+                case 'https':
+                    $components['port'] = 443;
+                    break;
+            }
+        }
+
         $this->url = $url;
         $this->components = $components;
     }


### PR DESCRIPTION
Proxy format needs special scheme (tcp:// or ssl://) for stream proxies, port is always needed in all cases.
- It looks like the proxy handling for both cURL and native PHP streams requires a port to work
- I updated the URL utility to add default ports for HTTP and HTTPS to let people be able to specify
  proxy as just and IP address or just an http:// address without a port. Not sure this is needed.
  (causes tests to break — see below)
- For stream based proxies, needed to build out the URL correctly. As it was, the `getUrl` was a runtime
  error since it did not exist.

Tests are broken with this patch. I see that master currently strips `:80` and `:443` for HTTP and HTTPS for `getHost`. I think these tests should work just fine once merged from master. Right now tests fail with the likes of "Expected http://example.com but Actual http://example.com:80".

I can rebase against master and make sure all of the tests work if you prefer. Please let me know!
