### PR TITLE
See notes at http://nl.php.net/manual/en/context.http.php

### DIFF
--- a/lib/Buzz/Client/FileGetContents.php
+++ b/lib/Buzz/Client/FileGetContents.php
@@ -63,7 +63,7 @@ class FileGetContents extends AbstractStream implements ClientInterface
         }
         $response->setHeaders(array_slice($http_response_header, key($http_response_header)));
 
-        if ($response->getStatusCode() == 302) {
+        if ($response->isRedirection()) {
             throw new \RuntimeException('Maximum ('.$this->maxRedirects.') redirects followed');
         }
         $response->setContent($content);


### PR DESCRIPTION
file_get_contents just merges the headers of all redirected requests into one big request. This commit works around that.

Before this change, a 200 OK result after a 302 Redirect response would still give $response->isRedirection() true.
