### PR TITLE
We need to set CURLOPT_POST = false for GET request, because after we…

### DIFF
--- a/lib/Buzz/Client/Curl.php
+++ b/lib/Buzz/Client/Curl.php
@@ -26,6 +26,7 @@ class Curl extends AbstractClient implements ClientInterface
             CURLOPT_HTTPHEADER    => $request->getHeaders(),
             CURLOPT_HTTPGET       => false,
             CURLOPT_NOBODY        => false,
+            CURLOPT_POST          => false,
             CURLOPT_POSTFIELDS    => null,
         );
 
@@ -35,11 +36,12 @@ class Curl extends AbstractClient implements ClientInterface
                 break;
 
             case Message\Request::METHOD_GET:
-                $options[CURLOPT_POST] = false;
                 $options[CURLOPT_HTTPGET] = true;
                 break;
 
             case Message\Request::METHOD_POST:
+                $options[CURLOPT_POST] = true;
+                
             case Message\Request::METHOD_PUT:
             case Message\Request::METHOD_DELETE:
             case Message\Request::METHOD_PATCH:


### PR DESCRIPTION
...create CURLOPT_POSTFIELDS Curl starts thinking, that we are using POST and adds "Content-Type: application/x-www-form-urlencoded" header, which we should not have, but we can not even remove it.
