### PR TITLE
Made Curl client handle content which looks like headers well

### DIFF
--- a/lib/Buzz/Message/Response.php
+++ b/lib/Buzz/Message/Response.php
@@ -71,20 +71,6 @@ class Response extends AbstractMessage
         $this->resetStatusLine();
     }
 
-    public function fromString($raw)
-    {
-        $lines = preg_split('/(\\r?\\n)/', $raw, -1, PREG_SPLIT_DELIM_CAPTURE);
-        for ($i = 0, $count = count($lines); $i < $count; $i += 2) {
-            $line = $lines[$i];
-            if (empty($line)) {
-                $this->setContent(implode('', array_slice($lines, $i + 2)));
-                break;
-            }
-
-            $this->addHeader($line);
-        }
-    }
-
     /**
      * Is response invalid?
      *

--- a/test/Buzz/Test/Client/FunctionalTest.php
+++ b/test/Buzz/Test/Client/FunctionalTest.php
@@ -135,6 +135,20 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('math' => '1+1=2'), $fields);
     }
 
+    /**
+     * @dataProvider provideClient
+     */
+    public function testClientHandlesContentWithFakeHeadersWell($client)
+    {
+        $request = new FormRequest();
+        $request->fromUrl($_SERVER['TEST_SERVER'].'?emulate=header');
+        $response = new Response();
+        $client->send($request, $response);
+
+        $this->assertEquals("HTTP/1.1 500 Fake error\r\nContent-length: 7\r\n\r\nContent", $response->getContent());
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
     public function provideClient()
     {
         return array(

--- a/test/Buzz/Test/Message/ResponseTest.php
+++ b/test/Buzz/Test/Message/ResponseTest.php
@@ -50,27 +50,6 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Internal Server Error', $response->getReasonPhrase());
     }
 
-    public function testFromString()
-    {
-        $content = <<<EOF
-This is the body.
-
-More body!
-
-EOF;
-        $response = new Response();
-        $response->fromString(<<<EOF
-HTTP/1.0 200 OK
-Content-Type: text/plain
-
-$content
-EOF
-        );
-
-        $this->assertEquals(2, count($response->getHeaders()));
-        $this->assertEquals($content, $response->getContent());
-    }
-
     public function testAddHeadersResetsStatusLine()
     {
         $response = new Response();

--- a/test/server.php
+++ b/test/server.php
@@ -1,5 +1,10 @@
 <?php
 
+if (@$_GET['emulate'] == 'header') {
+    echo "HTTP/1.1 500 Fake error\r\nContent-length: 7\r\n\r\nContent";
+    exit;
+}
+
 echo json_encode(array(
     'SERVER' => $_SERVER,
     'GET'    => $_GET,


### PR DESCRIPTION
As mentioned in #65

I the content of a request looks like a header, Curl will actually recognize it as a header and fail to correctly decompose the response into headers and content.

This PR will use curl_getinfo($this->curl, CURLINFO_HEADER_SIZE) to correctly figure out where the header stops and the content begins.

I ran into some issues while trying to achive this, the biggest being never really being able to rely on whether \r\n is used for newlines, or only \n. curl_getinfo($this->curl, CURLINFO_HEADER_SIZE) includes the two newlines which conclude the headers, so by diffing the headers and the trimmed headers, I was able to accurately distract and use it later on.

Since there was no way to return this delimiter from the getLastResponse method, I decided to return an array containing an array of headers and the body from that method, and actually remove the fromString method in the Response method, because, as said, this method had no way of reliably knowing whether \r\n or \n was used.
