### PR TITLE
Use separate curl instances for each curl request

### DIFF
--- a/lib/Buzz/Client/Curl.php
+++ b/lib/Buzz/Client/Curl.php
@@ -26,7 +26,6 @@ class Curl extends AbstractClient implements ClientInterface
             CURLOPT_HTTPHEADER    => $request->getHeaders(),
             CURLOPT_HTTPGET       => false,
             CURLOPT_NOBODY        => false,
-            CURLOPT_POSTFIELDS    => null,
         );
 
         switch ($request->getMethod()) {
@@ -115,9 +114,7 @@ class Curl extends AbstractClient implements ClientInterface
 
     public function send(Message\Request $request, Message\Response $response)
     {
-        if (false === is_resource($this->curl)) {
-            $this->curl = static::createCurlHandle();
-        }
+        $this->curl = static::createCurlHandle();
 
         $this->prepare($request, $response, $this->curl);
 

--- a/test/Buzz/Test/Client/FunctionalTest.php
+++ b/test/Buzz/Test/Client/FunctionalTest.php
@@ -136,6 +136,22 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('math' => '1+1=2'), $fields);
     }
 
+    /**
+     * @dataProvider provideClient
+     */
+    public function testGetShouldntSendContentType($client)
+    {
+        $request = new Request('GET');
+        $request->fromUrl($_SERVER['TEST_SERVER']);
+        $response = new Response();
+        $client->send($request, $response);
+
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertNotEquals('application/x-www-form-urlencoded', $data['SERVER']['CONTENT_TYPE']);
+        $this->assertEmpty($data['SERVER']['CONTENT_TYPE']);
+    }
+
     public function provideClient()
     {
         return array(


### PR DESCRIPTION
PHP seems to keep some internal state for the curl handles that cannot
be unset. When for example setting the `CURLOPT_POSTFIELDS` to `null`, a
Content-Type header will always be added for the request. This cannot be
unset. Issues like #68 seem to arise from this.

This PR should fix #68 and maybe even some other issues that could arise from re-using the handle.

[![Build Status](https://secure.travis-ci.org/asm89/Buzz.png?branch=curl-instances)](http://travis-ci.org/asm89/Buzz)
