### PR TITLE
Fix functional test setup with nginx (trivis-ci)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ php:
   - 5.3
   - 5.4
 
+before_install:
+    - echo "" | sudo add-apt-repository ppa:nginx/stable && sudo apt-get update && sudo apt-get -qq install nginx > /dev/null 2>&1
+
 before_script:
-    - sudo apt-get -qq install nginx > /dev/null 2>&1
     - php-cgi -b 127.0.0.1:9000 &
     - nginx -v && sudo nginx -c nginx.conf.dist -p test
     - export TEST_SERVER="http://localhost:8080/server.php"

--- a/test/nginx.conf.dist
+++ b/test/nginx.conf.dist
@@ -32,7 +32,8 @@ http {
 
             fastcgi_param  QUERY_STRING       $query_string;
             fastcgi_param  REQUEST_METHOD     $request_method;
-            fastcgi_param  CONTENT_TYPE       $content_type;
+            fastcgi_param  CONTENT_TYPE       $content_type if_not_empty;
+
             fastcgi_param  CONTENT_LENGTH     $content_length;
 
             fastcgi_param  SCRIPT_FILENAME    $document_root$fastcgi_script_name;


### PR DESCRIPTION
The issue with the `Content-Type` header is fixed now, but the tests are failing on travis because of the nginx configuration (and version). After this PR everything should be fine again:
[![Build Status](https://secure.travis-ci.org/asm89/Buzz.png?branch=fix-nginx-setup)](http://travis-ci.org/asm89/Buzz)
