### PR TITLE
new redirection tests and throw an exception in file_get_contents when max redirect is reached

### DIFF
--- a/lib/Buzz/Client/FileGetContents.php
+++ b/lib/Buzz/Client/FileGetContents.php
@@ -53,6 +53,10 @@ class FileGetContents extends AbstractStream implements ClientInterface
         $response->setHeaders($this->filterHeaders((array) $http_response_header));
         $response->setContent($content);
 
+        if ($response->isRedirection()) {
+            throw new \RuntimeException('Maximum ('.$this->maxRedirects.') redirects followed');
+        }
+
         if ($cookieJar) {
             $cookieJar->processSetCookieHeaders($request, $response);
         }

--- a/test/Buzz/Test/Client/FunctionalTest.php
+++ b/test/Buzz/Test/Client/FunctionalTest.php
@@ -150,6 +150,33 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideClient
      */
+    public function testRedirection($client)
+    {
+        $request = new Request(Request::METHOD_GET);
+        $request->fromUrl($_SERVER['TEST_SERVER'].'?redirect=3');
+
+        $response = $this->send($client, $request);
+
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertEquals('0', $data['GET']['redirect']);
+    }
+
+    /**
+     * @dataProvider provideClient
+     * @expectedException RuntimeException
+     */
+    public function testTooMuchRedirection($client)
+    {
+        $request = new Request(Request::METHOD_GET);
+        $request->fromUrl($_SERVER['TEST_SERVER'].'?redirect=8');
+
+        $this->send($client, $request);
+    }
+
+    /**
+     * @dataProvider provideClient
+     */
     public function testPlus($client)
     {
         $request = new FormRequest();

--- a/test/server.php
+++ b/test/server.php
@@ -5,6 +5,11 @@ if (isset($_GET['redirect_to'])) {
     die;
 }
 
+if (isset($_GET['redirect']) && $_GET['redirect']) {
+    header('Location: server.php?redirect='.($_GET['redirect']-1));
+    exit;
+}
+
 echo json_encode(array(
     'SERVER' => $_SERVER,
     'GET'    => $_GET,


### PR DESCRIPTION
I've split up my last PR in smaller bits as @kriswallsmith requested in #64. This one's got a failing test, but I'm not sure what the expected behavior is: Curl and FileGetContents throw RuntimeExceptions when the max level of redirections is reached, MultiCurl does not yet do this, as this could stop populating Results in the middle of the queue. What would the best solution be here?
