### PR TITLE
Add safeguard against misuse of the headers array

### DIFF
--- a/lib/Buzz/Browser.php
+++ b/lib/Buzz/Browser.php
@@ -77,6 +77,9 @@ class Browser
         $url->applyToRequest($request);
 
         foreach ($headers as $header) {
+            if (!is_int($key)) {
+                throw new \UnexpectedValueException('Headers must be an array of complete header strings, e.g. "Name: value", got: '.$header);
+            }
             $request->addHeader($header);
         }
 
@@ -106,6 +109,9 @@ class Browser
         $url->applyToRequest($request);
 
         foreach ($headers as $header) {
+            if (!is_int($key)) {
+                throw new \UnexpectedValueException('Headers must be an array of complete header strings, e.g. "Name: value", got: '.$header);
+            }
             $request->addHeader($header);
         }
 


### PR DESCRIPTION
I'm pretty sure it's not the first time I do the stupid mistake of sending `array('Header' => 'value');` and waste time debugging what the heck is happening. This would help. Alternatively we could do this, but it's maybe less BC (I mean, this isn't either, but at least this will fail loudly and not create more debugging hell):

```
        if (!is_int($key)) {
            $request->addHeader($key.': '.$header);
        }
```
