### PR TITLE
Don't change error reporting level

### DIFF
--- a/lib/Buzz/Message/Response.php
+++ b/lib/Buzz/Message/Response.php
@@ -176,13 +176,11 @@ class Response extends AbstractMessage
     private function parseStatusLine()
     {
         $headers = $this->getHeaders();
-        $count = count($parts = explode(' ', $headers[0], 3));
-        if (isset($headers[0]) && (2 == $count || 3 == $count)) {
+
+        if (isset($headers[0]) && 3 == count($parts = explode(' ', $headers[0], 3))) {
             $this->protocolVersion = (float) $parts[0];
             $this->statusCode = (integer) $parts[1];
-            if (isset($parts[2])) {
-                $this->reasonPhrase = $parts[2];
-            }
+            $this->reasonPhrase = $parts[2];
         } else {
             $this->protocolVersion = $this->statusCode = $this->reasonPhrase = false;
         }


### PR DESCRIPTION
Removing the lines which change the error reporting level to zero (off). This completely masks any problems with the URL, request, or response from the server, making debugging difficult. Using error_get_last in the next line to throw an exception does not always provide relevant information as file_get_contents will throw several errors on failure. Most errors seem to be warnings, so will not halt execution of the program and will allow you to see useful debugging information in the logs. Since the FileGetContents stream is the default one, I would expect a lot of people, especially new users like myself, to come up against this problem. This seems to be the only instance where the error reporting level is changed, so perhaps its ok to just get rid of it and let the users control the error reporting levels themselves?
