### PR TITLE
Update lib/Buzz/Client/AbstractCurl.php

### DIFF
--- a/lib/Buzz/Client/AbstractCurl.php
+++ b/lib/Buzz/Client/AbstractCurl.php
@@ -23,7 +23,7 @@ abstract class AbstractCurl extends AbstractClient
      */
     static protected function createCurlHandle()
     {
-        if (false === $curl = curl_init()) {
+        if (!function_exists("curl_init") || false === $curl = curl_init()) {
             throw new \RuntimeException('Unable to create a new cURL handle');
         }
 


### PR DESCRIPTION
Improved curl proper installation/initialization check

Without this check, if you have curl not installed/misconfigured, the `RuntimeException` is never thrown because everything is stopped by the following error:

```
Fatal error: Call to undefined function Buzz\Client\curl_init() in .../vendor/kriswallsmith/buzz/lib/Buzz/Client/AbstractCurl.php on line 26
```
