### PR TITLE
Improve `AbstractMessage#toDomDocument` for XML content.

### DIFF
--- a/lib/Buzz/Message/AbstractMessage.php
+++ b/lib/Buzz/Message/AbstractMessage.php
@@ -84,9 +84,10 @@ abstract class AbstractMessage implements MessageInterface
     public function toDomDocument()
     {
         $revert = libxml_use_internal_errors(true);
-
         $document = new \DOMDocument('1.0', $this->getHeaderAttribute('Content-Type', 'charset') ?: 'UTF-8');
-        $contentType = substr($this->getHeader('Content-Type'), strpos(';', $this->getHeader('Content-Type')));
+        $rawContentType = $this->getHeader('Content-Type');
+        $seperatorPosition = strpos($rawContentType, ';');
+        $contentType = FALSE !== $seperatorPosition ? trim(substr($rawContentType, 0, $seperatorPosition)) : $rawContentType;
 
         if ('text/xml' === $contentType) {
             $document->loadXML($this->getContent());

--- a/test/Buzz/Test/Message/AbstractMessageTest.php
+++ b/test/Buzz/Test/Message/AbstractMessageTest.php
@@ -113,7 +113,7 @@ XML;
         $this->assertEquals($expected, $message->toDomDocument()->saveXML());
     }
 
-    public function testToDomDocumentWithContentTypeTextXmlReturnsHTMLString()
+    public function testToDomDocumentWithContentTypeTextHTMLReturnsHTMLString()
     {
         $message = new Message();
         $expected = <<<HTML


### PR DESCRIPTION
This changes utilizes the value of the `Content-Type` header to determine what the best method is for loading the content into the `DOMDocument`.
