### PR TITLE
Allow only http and https protocols by default in curl client

### DIFF
--- a/lib/Buzz/Client/AbstractCurl.php
+++ b/lib/Buzz/Client/AbstractCurl.php
@@ -12,7 +12,15 @@ use Buzz\Message\RequestInterface;
  */
 abstract class AbstractCurl extends AbstractClient
 {
-    protected $options = array();
+    protected $options;
+
+    public function __construct()
+    {
+        $this->options = array(
+            CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+        );
+    }
 
     /**
      * Creates a new cURL resource.

--- a/test/Buzz/Test/Client/FunctionalTest.php
+++ b/test/Buzz/Test/Client/FunctionalTest.php
@@ -176,6 +176,18 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('200', $headers[0]);
     }
 
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Protocol pop3 not supported or disabled in libcurl
+     */
+    public function testRedirectedToForbiddenProtocol()
+    {
+        $client = new Curl();
+        $request = new Request();
+        $request->fromUrl($_SERVER['TEST_SERVER'].'?redirect_to=pop3://localhost/');
+        $response = $this->send($client, $request);
+    }
+
     public function provideClient()
     {
         return array(


### PR DESCRIPTION
Curl supports many protocols and by default it follows redirections to any url, with any supported protocol except file and scp: pop3, telnet, ftp, etc.

This PR sets default curl options to allow only HTTP and HTTPS protocols, since Buzz is only a HTTP client.
