### PR TITLE
Check for curl version before accessing options

### DIFF
--- a/lib/Buzz/Client/AbstractCurl.php
+++ b/lib/Buzz/Client/AbstractCurl.php
@@ -13,14 +13,17 @@ use Buzz\Exception\ClientException;
  */
 abstract class AbstractCurl extends AbstractClient
 {
-    protected $options;
+    protected $options = array();
 
     public function __construct()
     {
-        $this->options = array(
-            CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-        );
+        $curlVersion = curl_version();
+        if (version_compare($curlVersion['version'], '7.19.4', 'ge')) {
+            $this->options = array(
+                CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+                CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
A recent pull request (#105), added some curl options that are not configured on older versions of curl (http://php.net/manual/en/function.curl-setopt.php). I added a check to set these options only if the curl version is high enough.
