### PR TITLE
cURL Compatibility Improvement

### DIFF
--- a/lib/Buzz/Client/AbstractCurl.php
+++ b/lib/Buzz/Client/AbstractCurl.php
@@ -190,10 +190,10 @@ abstract class AbstractCurl extends AbstractClient
             curl_setopt($curl, CURLOPT_PROXY, $this->proxy);
         }
         
-        $can_follow = (!ini_get('safe_mode') && !ini_get('open_basedir'));
+        $canFollow = !ini_get('safe_mode') && !ini_get('open_basedir');
 
-        curl_setopt($curl, CURLOPT_FOLLOWLOCATION, ($can_follow && $this->getMaxRedirects() > 0));
-        curl_setopt($curl, CURLOPT_MAXREDIRS, (($can_follow) ? $this->getMaxRedirects() : 0));
+        curl_setopt($curl, CURLOPT_FOLLOWLOCATION, $canFollow && $this->getMaxRedirects() > 0);
+        curl_setopt($curl, CURLOPT_MAXREDIRS, $canFollow ? $this->getMaxRedirects() : 0);
         curl_setopt($curl, CURLOPT_FAILONERROR, !$this->getIgnoreErrors());
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->getVerifyPeer());
 


### PR DESCRIPTION
Updating `prepare()` so that it considers the current PHP environment. `safe_mode` and `open_basedir` will not allow `cURL` to `FOLLOWLOCATION`.

See also: http://www.edmondscommerce.co.uk/curl/php-curl-curlopt_followlocation-and-open_basedir-or-safe-mode/
