### PR TITLE
Override php.ini setting *arg_separator.output*

### DIFF
--- a/lib/Buzz/Client/AbstractCurl.php
+++ b/lib/Buzz/Client/AbstractCurl.php
@@ -129,7 +129,7 @@ abstract class AbstractCurl extends AbstractClient
             }
         }
 
-        return $multipart ? $fields : http_build_query($fields);
+        return $multipart ? $fields : http_build_query($fields, '', '&');
     }
 
     /**


### PR DESCRIPTION
Override php.ini setting _arg_separator.output_ to prevent errors.
Like "&amp;" instead of "&".
