### PR TITLE
Remove the "HTTP/1.0 200 Connection established" string from the respons...

### DIFF
--- a/lib/Buzz/Client/Curl.php
+++ b/lib/Buzz/Client/Curl.php
@@ -28,6 +28,11 @@ class Curl extends AbstractCurl
 
             throw new ClientException($errorMsg, $errorNo);
         }
+        
+        // cURL automatically handles Proxy rewrites, remove the "HTTP/1.0 200 Connection established" string
+        if ($this->proxy && false !== stripos($data, "HTTP/1.0 200 Connection established\r\n\r\n")) {
+            $data = str_ireplace("HTTP/1.0 200 Connection established\r\n\r\n", '', $data);
+        }
 
         static::populateResponse($this->lastCurl, $data, $response);
     }


### PR DESCRIPTION
At my company, when using cURL, we always need to go through a proxy. The problem is that when a request goes through a proxy, the first line of the response always includes:

HTTP/1.0 200 Connection established

If this string is included in the response, the response is not correctly parsed in populateResponse.

An example:

A typical response when we go through a proxy:

HTTP/1.0 200 Connection established

HTTP/1.1 404 Not Found
Server: Apache-Coyote/1.1
Pragma: no-cache
Cache-Control: no-cache
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Cache-Control: no-store
Content-Length: 13
Date: Wed, 13 Feb 2013 16:36:43 GMT
