### PR TITLE
Fix of infinity loop

### DIFF
--- a/lib/Buzz/Client/MultiCurl.php
+++ b/lib/Buzz/Client/MultiCurl.php
@@ -35,11 +35,13 @@ class MultiCurl extends AbstractCurl implements BatchClientInterface
         } while (CURLM_CALL_MULTI_PERFORM == $mrc);
 
         while ($active && CURLM_OK == $mrc) {
-            if (-1 != curl_multi_select($curlm)) {
-                do {
-                    $mrc = curl_multi_exec($curlm, $active);
-                } while (CURLM_CALL_MULTI_PERFORM == $mrc);
+            if (curl_multi_select($curlm, $active) === -1) {
+                usleep(100);
             }
+
+            do {
+                $mrc = curl_multi_exec($curlm, $active);
+            } while (CURLM_CALL_MULTI_PERFORM == $mrc);
         }
 
         // populate the responses


### PR DESCRIPTION
The infinity loop is happening always on my PC (Win32) and on my colleague's PC (linux). It was not happening on the third PC with MacOS.
More info at https://bugs.php.net/bug.php?id=63842

The documentation of http://php.net/manual/en/function.curl-multi-init.php is not right.

Citation:

---

The current example is definitely an incorrect way of doing things, and was 
causing an infinite loop for me today.

From the cURL documentation 
(http://curl.haxx.se/libcurl/c/curl_multi_fdset.html):

When libcurl returns -1 in max_fd, it is because libcurl currently does 
something that isn't possible for your application to monitor with a socket and 
unfortunately you can then not know exactly when the current action is completed 
using select(). When max_fd returns with -1, you need to wait a while and then 
proceed and call curl_multi_perform anyway. How long to wait? I would suggest 
100 milliseconds at least, but you may want to test it out in your own 
particular conditions to find a suitable value.

So in the situation where libcurl can't use select(), it will always return -1, 
and thus the example will be an infinite loop, as I have been experiencing.  I 
changed my code to the following, and it now works:

``` php
    while ($active && $mrc == CURLM_OK) {
      if (curl_multi_select($mh) === -1) {
        usleep(100);
      }
      do {
        $mrc = curl_multi_exec($mh, $active);
      } while ($mrc == CURLM_CALL_MULTI_PERFORM);
    }
```
