### PR TITLE
Return empty string instead of `false` on empty response with headers

### DIFF
--- a/lib/Buzz/Client/AbstractCurl.php
+++ b/lib/Buzz/Client/AbstractCurl.php
@@ -56,7 +56,7 @@ abstract class AbstractCurl extends AbstractClient
         $pos = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
 
         $response->setHeaders(static::getLastHeaders(rtrim(substr($raw, 0, $pos))));
-        $response->setContent(substr($raw, $pos));
+        $response->setContent(strlen($raw) > $pos ? substr($raw, $pos) : '');
     }
 
     /**


### PR DESCRIPTION
In case of server response contains some headers but `Content-Length` header has `0` value, then the `false` is returned instead of empty string as a response.

I've fixed similar issue https://github.com/alexandresalome/PHP-Selenium/pull/5 too.

In particular this prevents https://github.com/Behat/SahiClient from working properly, when trying to get an attribute value.
