### PR TITLE
Set default headers on Browser

### DIFF
--- a/lib/Buzz/Browser.php
+++ b/lib/Buzz/Browser.php
@@ -19,6 +19,7 @@ class Browser
     private $listener;
     private $lastRequest;
     private $lastResponse;
+    private $headers = array();
 
     public function __construct(ClientInterface $client = null, FactoryInterface $factory = null)
     {
@@ -76,7 +77,7 @@ class Browser
 
         $url->applyToRequest($request);
 
-        $request->addHeaders($headers);
+        $request->addHeaders(array_merge($this->headers, $headers));
         $request->setContent($content);
 
         return $this->send($request);
@@ -102,7 +103,7 @@ class Browser
 
         $url->applyToRequest($request);
 
-        $request->addHeaders($headers);
+        $request->addHeaders(array_merge($this->headers, $headers));
         $request->setMethod($method);
         $request->setFields($fields);
 
@@ -191,5 +192,13 @@ class Browser
                 $listener,
             ));
         }
+    }
+
+    public function setDefaultHeaders(array $headers) {
+        $this->headers = $headers;
+    }
+
+    public function getDefaultHeaders() {
+        return $this->headers;
     }
 }

--- a/test/Buzz/Test/BrowserTest.php
+++ b/test/Buzz/Test/BrowserTest.php
@@ -179,4 +179,52 @@ class BrowserTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Buzz\Listener\ListenerChain', $listenerChain);
         $this->assertEquals(3, count($listenerChain->getListeners()));
     }
+
+    public function testDefaultHeadersEmpty() {
+        $request = $this->getMock('Buzz\Message\RequestInterface');
+        $response = $this->getMock('Buzz\Message\MessageInterface');
+        $headers = array('X-Foo: bar');
+
+        $this->factory->expects($this->once())
+            ->method('createRequest')
+            ->with('GET')
+            ->will($this->returnValue($request));
+        $this->factory->expects($this->once())
+            ->method('createResponse')
+            ->will($this->returnValue($response));
+
+        $request->expects($this->once())
+            ->method('addHeaders')
+            ->with($headers);
+
+        $this->assertSame(array(), $this->browser->getDefaultHeaders());
+
+        $this->browser->get('http://google.com/', $headers);
+
+    }
+
+    public function testDefaultHeaders() {
+        $request = $this->getMock('Buzz\Message\RequestInterface');
+        $response = $this->getMock('Buzz\Message\MessageInterface');
+        $defaultHeader = 'X-Default: baz';
+        $header = 'X-Foo: bar';
+
+        $this->factory->expects($this->once())
+            ->method('createRequest')
+            ->with('GET')
+            ->will($this->returnValue($request));
+        $this->factory->expects($this->once())
+            ->method('createResponse')
+            ->will($this->returnValue($response));
+
+        $request->expects($this->once())
+            ->method('addHeaders')
+            ->with(array($defaultHeader, $header));
+
+        $this->browser->setDefaultHeaders(array($defaultHeader));
+        $this->assertSame(array($defaultHeader), $this->browser->getDefaultHeaders());
+
+        $this->browser->get('http://google.com/', array($header));
+
+    }
 }


### PR DESCRIPTION
Allows for setting default headers on the Browser instance that are merged into each request
