### PR TITLE
Fix php error "Undefined variable: http_response_header" in FileGetContents

### DIFF
--- a/lib/Buzz/Client/FileGetContents.php
+++ b/lib/Buzz/Client/FileGetContents.php
@@ -63,6 +63,10 @@ class FileGetContents extends AbstractStream
             throw new ClientException($error['message']);
         }
 
+        if (!isset($http_response_header)) {
+            $http_response_header = array();
+        }
+
         $response->setHeaders($this->filterHeaders((array) $http_response_header));
         $response->setContent($content);
 

--- a/test/Buzz/Test/Client/FileGetContentsTest.php
+++ b/test/Buzz/Test/Client/FileGetContentsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Buzz\Test\Client;
+
+use Buzz\Message;
+use Buzz\Client\FileGetContents;
+
+class FileGetContentsTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSend()
+    {
+        $request = new Message\Request(Message\Request::METHOD_GET, '/response.txt',__DIR__.'/fixtures');
+
+        $response = new Message\Response();
+        $client = new FileGetContents();
+
+        $client->send($request, $response);
+
+        $this->assertEquals(array(), $response->getHeaders());
+        $this->assertEquals(file_get_contents(__DIR__.'/fixtures/response.txt'), $response->getContent());
+    }
+}

--- a/test/Buzz/Test/Client/fixtures/response.txt
+++ b/test/Buzz/Test/Client/fixtures/response.txt
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<root></root>


### PR DESCRIPTION
When using the FileGetContents client, if the resource is a file the $http_response_header variable will not contain the headers of the call.

This PR will create the $http_response_header variable if it is not defined after calling file_get_contents on the resource.
