### PR TITLE
Added Added CURLOPT_SSL_VERIFYHOST options for Curl clients

### DIFF
--- a/lib/Buzz/Client/AbstractClient.php
+++ b/lib/Buzz/Client/AbstractClient.php
@@ -8,6 +8,7 @@ abstract class AbstractClient implements ClientInterface
     protected $maxRedirects = 5;
     protected $timeout = 5;
     protected $verifyPeer = true;
+    protected $verifyHost = 2;
     protected $proxy;
 
     public function setIgnoreErrors($ignoreErrors)
@@ -48,6 +49,16 @@ abstract class AbstractClient implements ClientInterface
     public function getVerifyPeer()
     {
         return $this->verifyPeer;
+    }
+
+    public function setVerifyHost($verifyHost)
+    {
+        $this->verifyHost = $verifyHost;
+    }
+
+    public function getVerifyHost()
+    {
+        return $this->verifyHost;
     }
 
     public function setProxy($proxy)

--- a/lib/Buzz/Client/AbstractCurl.php
+++ b/lib/Buzz/Client/AbstractCurl.php
@@ -192,13 +192,14 @@ abstract class AbstractCurl extends AbstractClient
         if ($this->proxy) {
             curl_setopt($curl, CURLOPT_PROXY, $this->proxy);
         }
-        
+
         $canFollow = !ini_get('safe_mode') && !ini_get('open_basedir');
 
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, $canFollow && $this->getMaxRedirects() > 0);
         curl_setopt($curl, CURLOPT_MAXREDIRS, $canFollow ? $this->getMaxRedirects() : 0);
         curl_setopt($curl, CURLOPT_FAILONERROR, !$this->getIgnoreErrors());
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->getVerifyPeer());
+        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, $this->getVerifyHost());
 
         // apply additional options
         curl_setopt_array($curl, $options + $this->options);


### PR DESCRIPTION
I was getting the subject name does not match target host name error on Ubuntu 12.04 and PHP 5.3.10 and setting VERIFYHOST to false has solved this issue. I was not getting the same issue when using PHP 5.4.25 on Ubuntu 12.04. In any case, I thought having this option would help others experiencing the same issue.

Also, if anyone could show me how to go about creating a test for this, that would be great.