### PR TITLE
Switch travis to use php-fpm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ before_install:
     - sudo stop squid3
 
 before_script:
-    - php-cgi -b 127.0.0.1:8888 &
+    - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+    - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+    - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
     - sudo nginx -p test -c etc/nginx.conf
     - sudo squid3 -f test/etc/squid.conf
     - composer self-update

--- a/test/etc/nginx.conf
+++ b/test/etc/nginx.conf
@@ -13,7 +13,7 @@ http {
     fastcgi_intercept_errors on;
 
     upstream php {
-        server 127.0.0.1:8888;
+        server 127.0.0.1:9000;
     }
 
     access_log /var/log/nginx/access.log;


### PR DESCRIPTION
I have modified .travis.yml to use php-fpm using the commands detailed in the travis-ci docs for PHP:
http://docs.travis-ci.com/user/languages/php/

I have also changed the port in the nginx.conf file to 9000 from 8888 as this is the default for php-fpm.
