### PR TITLE
[Response] Fix protocol version parsing

### DIFF
--- a/lib/Buzz/Message/Response.php
+++ b/lib/Buzz/Message/Response.php
@@ -178,7 +178,7 @@ class Response extends AbstractMessage
         $headers = $this->getHeaders();
 
         if (isset($headers[0]) && 3 == count($parts = explode(' ', $headers[0], 3))) {
-            $this->protocolVersion = (float) $parts[0];
+            $this->protocolVersion = (float) substr($parts[0], 5);
             $this->statusCode = (integer) $parts[1];
             $this->reasonPhrase = $parts[2];
         } else {

--- a/test/Buzz/Test/Message/ResponseTest.php
+++ b/test/Buzz/Test/Message/ResponseTest.php
@@ -12,7 +12,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($response->getProtocolVersion());
 
-        $response->addHeader('1.0 200 OK');
+        $response->addHeader('HTTP/1.0 200 OK');
 
         $this->assertEquals(1.0, $response->getProtocolVersion());
     }
@@ -23,7 +23,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($response->getStatusCode());
 
-        $response->addHeader('1.0 200 OK');
+        $response->addHeader('HTTP/1.0 200 OK');
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -34,7 +34,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($response->getReasonPhrase(), null);
 
-        $response->addHeader('1.0 200 OK');
+        $response->addHeader('HTTP/1.0 200 OK');
 
         $this->assertEquals('OK', $response->getReasonPhrase());
     }
@@ -45,7 +45,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($response->getReasonPhrase());
 
-        $response->addHeader('1.0 500 Internal Server Error');
+        $response->addHeader('HTTP/1.0 500 Internal Server Error');
 
         $this->assertEquals('Internal Server Error', $response->getReasonPhrase());
     }
@@ -54,7 +54,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     {
         $response = new Response();
         $this->assertNull($response->getStatusCode());
-        $response->addHeaders(array('1.0 200 OK'));
+        $response->addHeaders(array('HTTP/1.0 200 OK'));
         $this->assertEquals(200, $response->getStatusCode());
     }
 
@@ -66,7 +66,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     public function testIssers($code, $method, $expected)
     {
         $response = new Response();
-        $response->addHeaders(array('1.0 '.$code.' Status'));
+        $response->addHeaders(array('HTTP/1.0 '.$code.' Status'));
         $this->assertEquals($expected, $response->{$method}());
     }
 


### PR DESCRIPTION
Hey!

This PR fixes the response protocol version parsing. According to the [RFC-2616 Section 3.1](http://tools.ietf.org/html/rfc2616#section-3.1), the status line is formatted as `HTTP-Version = "HTTP" "/" 1*DIGIT "." 1*DIGIT`
