### PR TITLE
[Curl] Add options request body support

### DIFF
--- a/lib/Buzz/Client/AbstractCurl.php
+++ b/lib/Buzz/Client/AbstractCurl.php
@@ -83,6 +83,7 @@ abstract class AbstractCurl extends AbstractClient
             case RequestInterface::METHOD_PUT:
             case RequestInterface::METHOD_DELETE:
             case RequestInterface::METHOD_PATCH:
+            case RequestInterface::METHOD_OPTIONS:
                 $options[CURLOPT_POSTFIELDS] = $fields = static::getPostFields($request);
 
                 // remove the content-type header

--- a/test/Buzz/Test/Client/FunctionalTest.php
+++ b/test/Buzz/Test/Client/FunctionalTest.php
@@ -221,7 +221,7 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
         // HEAD is intentionally omitted
         // http://stackoverflow.com/questions/2603104/does-mod-php-honor-head-requests-properly
 
-        $methods = array('GET', 'POST', 'PUT', 'DELETE', 'PATCH');
+        $methods = array('GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS');
         $clients = $this->provideClient();
 
         $data = array();


### PR DESCRIPTION
Hey!

This PR adds the body support for options request. According to the [RFC-2616 Section 9.2](http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.2), the options request can wraps a body.
