### PR TITLE
[Client][Stream] Fix max redirects

### DIFF
--- a/lib/Buzz/Client/AbstractStream.php
+++ b/lib/Buzz/Client/AbstractStream.php
@@ -25,7 +25,7 @@ abstract class AbstractStream extends AbstractClient
 
                 // values from the current client
                 'ignore_errors'    => $this->getIgnoreErrors(),
-                'max_redirects'    => $this->getMaxRedirects(),
+                'max_redirects'    => $this->getMaxRedirects() + 1,
                 'timeout'          => $this->getTimeout(),
             ),
             'ssl' => array(

--- a/test/Buzz/Test/Client/AbstractStreamTest.php
+++ b/test/Buzz/Test/Client/AbstractStreamTest.php
@@ -34,7 +34,7 @@ class AbstractStreamTest extends \PHPUnit_Framework_TestCase
                 'content'          => 'foo=bar&bar=baz',
                 'protocol_version' => 1.0,
                 'ignore_errors'    => false,
-                'max_redirects'    => 5,
+                'max_redirects'    => 6,
                 'timeout'          => 10,
             ),
             'ssl' => array(


### PR DESCRIPTION
Hey!

This PR fixes an issue with max redirects on the stream client. Basically, if you read the [doc](http://php.net/manual/en/context.http.php#context.http.max-redirects) about max redirects, it explains `Value 1 or less means that no redirects are followed.` (Pretty not intuitive but it's how it works...) So, if you configure the stream client to follow one redirect, it will not follow it whereas the curl client will. Additionally, there are more subtleties as for example, configuring 5 redirects will only allow 4 real redirects. So, this PR rationalizes the behavior between the different clients.
