### PR TITLE
[Client][Stream] Allow to get redirect request with ignore errors configured as false

### DIFF
--- a/lib/Buzz/Client/AbstractStream.php
+++ b/lib/Buzz/Client/AbstractStream.php
@@ -25,13 +25,17 @@ abstract class AbstractStream extends AbstractClient
 
                 // values from the current client
                 'ignore_errors'    => $this->getIgnoreErrors(),
-                'max_redirects'    => $this->getMaxRedirects() + 1,
+                'follow_location'  => $this->getMaxRedirects() > 0,
                 'timeout'          => $this->getTimeout(),
             ),
             'ssl' => array(
                 'verify_peer'      => $this->getVerifyPeer(),
             ),
         );
+
+        if ($this->getMaxRedirects() > 0) {
+            $options['http']['max_redirects'] = $this->getMaxRedirects() + 1;
+        }
 
         if ($this->proxy) {
             $options['http']['proxy'] = $this->proxy;

--- a/test/Buzz/Test/Client/AbstractStreamTest.php
+++ b/test/Buzz/Test/Client/AbstractStreamTest.php
@@ -34,6 +34,7 @@ class AbstractStreamTest extends \PHPUnit_Framework_TestCase
                 'content'          => 'foo=bar&bar=baz',
                 'protocol_version' => 1.0,
                 'ignore_errors'    => false,
+                'follow_location'  => true,
                 'max_redirects'    => 6,
                 'timeout'          => 10,
             ),
@@ -46,6 +47,11 @@ class AbstractStreamTest extends \PHPUnit_Framework_TestCase
 
         $client->setVerifyPeer(true);
         $expected['ssl']['verify_peer'] = true;
+        $this->assertEquals($expected, $client->getStreamContextArray($request));
+
+        $client->setMaxRedirects(0);
+        $expected['http']['follow_location'] = false;
+        unset($expected['http']['max_redirects']);
         $this->assertEquals($expected, $client->getStreamContextArray($request));
     }
 }


### PR DESCRIPTION
Hey!

This PR rationalizes the behavior between curl and stream clients. Given you configure the curl client with a max redirects as 0 and ignore errors as false. The curl client will give you the response (302) without any trouble. If you try to do the same thing with the stream client, it failed. It is due to the fact the max redirects is set to 0 which does not allow anything and `file_get_contents` will return false and so, throw an exception. This PR disables the redirects with the `follow_location` option and let the `max_redirects` with his default value.

Additionally, #82 can be closed as it already throws an exception if we set the ignore errors to false.
