### PR TITLE
Added support for CURLOPT_SSL_VERIFYHOST

### DIFF
--- a/lib/Buzz/Client/AbstractClient.php
+++ b/lib/Buzz/Client/AbstractClient.php
@@ -8,6 +8,7 @@ abstract class AbstractClient implements ClientInterface
     protected $maxRedirects = 5;
     protected $timeout = 5;
     protected $verifyPeer = true;
+    protected $verifyHost = 2;
     protected $proxy;
 
     public function setIgnoreErrors($ignoreErrors)
@@ -48,6 +49,16 @@ abstract class AbstractClient implements ClientInterface
     public function getVerifyPeer()
     {
         return $this->verifyPeer;
+    }
+
+    public function setVerifyHost($verifyHost)
+    {
+        $this->verifyHost = $verifyHost;
+    }
+
+    public function getVerifyHost()
+    {
+        return $this->verifyHost;
     }
 
     public function setProxy($proxy)

--- a/lib/Buzz/Client/AbstractCurl.php
+++ b/lib/Buzz/Client/AbstractCurl.php
@@ -224,6 +224,7 @@ abstract class AbstractCurl extends AbstractClient
         curl_setopt($curl, CURLOPT_MAXREDIRS, $canFollow ? $this->getMaxRedirects() : 0);
         curl_setopt($curl, CURLOPT_FAILONERROR, !$this->getIgnoreErrors());
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->getVerifyPeer());
+        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, $this->getVerifyHost());
 
         // apply additional options
         curl_setopt_array($curl, $options + $this->options);

--- a/lib/Buzz/Client/AbstractStream.php
+++ b/lib/Buzz/Client/AbstractStream.php
@@ -19,7 +19,7 @@ abstract class AbstractStream extends AbstractClient
             'http' => array(
                 // values from the request
                 'method'           => $request->getMethod(),
-                'header'           => implode("\r\n", $request->getHeaders()),
+                'header'           => implode(PHP_EOL, $request->getHeaders()),
                 'content'          => $request->getContent(),
                 'protocol_version' => $request->getProtocolVersion(),
 

--- a/lib/Buzz/Client/AbstractStream.php
+++ b/lib/Buzz/Client/AbstractStream.php
@@ -30,6 +30,7 @@ abstract class AbstractStream extends AbstractClient
             ),
             'ssl' => array(
                 'verify_peer'      => $this->getVerifyPeer(),
+                'verify_host'      => $this->getVerifyHost(),
             ),
         );
 

--- a/test/Buzz/Test/Client/AbstractStreamTest.php
+++ b/test/Buzz/Test/Client/AbstractStreamTest.php
@@ -40,13 +40,16 @@ class AbstractStreamTest extends \PHPUnit_Framework_TestCase
             ),
             'ssl' => array(
                 'verify_peer'      => true,
+                'verify_host'      => 2,
             ),
         );
 
         $this->assertEquals($expected, $client->getStreamContextArray($request));
 
         $client->setVerifyPeer(true);
+        $client->setVerifyHost(2);
         $expected['ssl']['verify_peer'] = true;
+        $expected['ssl']['verify_host'] = 2;
         $this->assertEquals($expected, $client->getStreamContextArray($request));
 
         $client->setMaxRedirects(0);

--- a/test/Buzz/Test/Client/AbstractStreamTest.php
+++ b/test/Buzz/Test/Client/AbstractStreamTest.php
@@ -30,7 +30,7 @@ class AbstractStreamTest extends \PHPUnit_Framework_TestCase
         $expected = array(
             'http' => array(
                 'method'           => 'POST',
-                'header'           => "Content-Type: application/x-www-form-urlencoded\r\nContent-Length: 15",
+                'header'           => "Content-Type: application/x-www-form-urlencoded" . PHP_EOL . "Content-Length: 15",
                 'content'          => 'foo=bar&bar=baz',
                 'protocol_version' => 1.0,
                 'ignore_errors'    => false,
@@ -38,9 +38,9 @@ class AbstractStreamTest extends \PHPUnit_Framework_TestCase
                 'max_redirects'    => 6,
                 'timeout'          => 10,
             ),
-            'ssl' => array(
-                'verify_peer'      => true,
-                'verify_host'      => 2,
+            'ssl'  => array(
+                'verify_peer' => true,
+                'verify_host' => 2,
             ),
         );
 


### PR DESCRIPTION
This PR adds support for CURLOPT_SSL_VERIFYHOST option. Default value is
set to 2 according to documentation
(http://php.net//manual/pl/function.curl-setopt.php). There should not
be any BC issues.