### PR TITLE
[Client][Stream] Fix max redirects with PHP < 5.3.4

### DIFF
--- a/lib/Buzz/Client/AbstractStream.php
+++ b/lib/Buzz/Client/AbstractStream.php
@@ -26,16 +26,13 @@ abstract class AbstractStream extends AbstractClient
                 // values from the current client
                 'ignore_errors'    => $this->getIgnoreErrors(),
                 'follow_location'  => $this->getMaxRedirects() > 0,
+                'max_redirects'    => $this->getMaxRedirects() + 1,
                 'timeout'          => $this->getTimeout(),
             ),
             'ssl' => array(
                 'verify_peer'      => $this->getVerifyPeer(),
             ),
         );
-
-        if ($this->getMaxRedirects() > 0) {
-            $options['http']['max_redirects'] = $this->getMaxRedirects() + 1;
-        }
 
         if ($this->proxy) {
             $options['http']['proxy'] = $this->proxy;

--- a/test/Buzz/Test/Client/AbstractStreamTest.php
+++ b/test/Buzz/Test/Client/AbstractStreamTest.php
@@ -51,7 +51,7 @@ class AbstractStreamTest extends \PHPUnit_Framework_TestCase
 
         $client->setMaxRedirects(0);
         $expected['http']['follow_location'] = false;
-        unset($expected['http']['max_redirects']);
+        $expected['http']['max_redirects'] = 1;
         $this->assertEquals($expected, $client->getStreamContextArray($request));
     }
 }


### PR DESCRIPTION
Hey!

This PR fixes an issue with the previous patch I have submitted (#163). Basically, `follow_location` has been added in PHP 5.3.4, so in the previous version we must use `max_redirects` otherwise the redirects behavior is enabled. I have tested it and my conclusion is:
- PHP < 5.3.4: If we set `max_redirects` to 1 and `ignore_errors` to false, the 302 is returned
- PHP >= 5.3.4: If we set `follow_location` to false, `max_redirects` to 1 and `ignore_errors` to false, the 302 is returned.

My tests are https://travis-ci.org/egeloen/ivory-http-adapter/builds/31553140 (fail) and https://travis-ci.org/egeloen/ivory-http-adapter/builds/31554119 (pass)
