### PR TITLE
Fixed wrong check for uploaded file.

### DIFF
--- a/lib/Buzz/Client/AbstractCurl.php
+++ b/lib/Buzz/Client/AbstractCurl.php
@@ -127,7 +127,9 @@ abstract class AbstractCurl extends AbstractClient
                 continue;
             }
 
-            if (!$file = $value->getFile()) {
+            $file = $value->getFile();
+
+            if (empty($file)) {
                 return $request->getContent();
             }
 


### PR DESCRIPTION
When trying to upload a file, you got a 500 `Object of class Symfony\Component\HttpFoundation\File\UploadedFile could not be converted to boolean`. This should fix it.
