### PR TITLE
RequestException extends ClientException

### DIFF
--- a/lib/Buzz/Client/Curl.php
+++ b/lib/Buzz/Client/Curl.php
@@ -2,9 +2,9 @@
 
 namespace Buzz\Client;
 
+use Buzz\Exception\RequestException;
 use Buzz\Message\MessageInterface;
 use Buzz\Message\RequestInterface;
-use Buzz\Exception\ClientException;
 use Buzz\Exception\LogicException;
 
 class Curl extends AbstractCurl
@@ -26,7 +26,10 @@ class Curl extends AbstractCurl
             $errorMsg = curl_error($this->lastCurl);
             $errorNo  = curl_errno($this->lastCurl);
 
-            throw new ClientException($errorMsg, $errorNo);
+            $e = new RequestException($errorMsg, $errorNo);
+            $e->setRequest($request);
+
+            throw $e;
         }
 
         static::populateResponse($this->lastCurl, $data, $response);

--- a/lib/Buzz/Client/FileGetContents.php
+++ b/lib/Buzz/Client/FileGetContents.php
@@ -2,6 +2,7 @@
 
 namespace Buzz\Client;
 
+use Buzz\Exception\RequestException;
 use Buzz\Message\MessageInterface;
 use Buzz\Message\RequestInterface;
 use Buzz\Util\CookieJar;
@@ -60,7 +61,10 @@ class FileGetContents extends AbstractStream
         error_reporting($level);
         if (false === $content) {
             $error = error_get_last();
-            throw new ClientException($error['message']);
+            $e = new RequestException($error['message']);
+            $e->setRequest($request);
+
+            throw $e;
         }
 
         $response->setHeaders($this->filterHeaders((array) $http_response_header));

--- a/lib/Buzz/Exception/RequestException.php
+++ b/lib/Buzz/Exception/RequestException.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Buzz\Exception;
+
+use Buzz\Message\RequestInterface;
+
+class RequestException extends ClientException
+{
+    /**
+     * Request object
+     *
+     * @var RequestInterface
+     */
+    private $request;
+
+    /**
+     * @return RequestInterface
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * @param RequestInterface $request
+     */
+    public function setRequest(RequestInterface $request)
+    {
+        $this->request = $request;
+    }
+
+}


### PR DESCRIPTION
Hey,

Problem Scenario:
- HWIOAuthBundle is using the Buzz library ( https://github.com/hwi/HWIOAuthBundle )
- In case of a timeout error a ClientException will be thrown
- You can catch that exception in your application, but you don't have any access to the request object to log and error with the log with is causing a timeout.

Solution:
- Create a new Exception like RequestException
- Extend it with ClientException to have a 100% backwards compatibility
- Store the request object in the RequestException

Can you follow my problem scenario?

Would be very nice if you can merge it into your repo.
Feel free to drop a comment

Best regards,
Christian
