### PR TITLE
Allow to specify http proxy per-request

### DIFF
--- a/lib/Buzz/Client/AbstractCurl.php
+++ b/lib/Buzz/Client/AbstractCurl.php
@@ -70,6 +70,10 @@ abstract class AbstractCurl extends AbstractClient
             CURLOPT_HTTPHEADER    => $request->getHeaders(),
         );
 
+        if ($request->getProxy()) {
+            $options[CURLOPT_PROXY] = $request->getProxy();
+        }
+
         switch ($request->getMethod()) {
             case RequestInterface::METHOD_HEAD:
                 $options[CURLOPT_NOBODY] = true;

--- a/lib/Buzz/Message/Request.php
+++ b/lib/Buzz/Message/Request.php
@@ -9,6 +9,7 @@ class Request extends AbstractMessage implements RequestInterface
     private $method;
     private $resource;
     private $host;
+    private $proxy;
     private $protocolVersion = 1.0;
 
     /**
@@ -75,6 +76,16 @@ class Request extends AbstractMessage implements RequestInterface
     public function getHost()
     {
         return $this->host;
+    }
+
+    public function setProxy($proxy)
+    {
+        $this->proxy = $proxy;
+    }
+
+    public function getProxy()
+    {
+        return $this->proxy;
     }
 
     public function setProtocolVersion($protocolVersion)

--- a/lib/Buzz/Message/RequestInterface.php
+++ b/lib/Buzz/Message/RequestInterface.php
@@ -72,4 +72,18 @@ interface RequestInterface extends MessageInterface
      * @return Boolean True if the request is secure
      */
     public function isSecure();
+
+    /**
+     * Returns the value of the http proxy host.
+     *
+     * @return string|null The proxy host
+     */
+    public function getProxy();
+
+    /**
+     * Sets the http proxy host for the current request.
+     *
+     * @param string $proxy The proxy host
+     */
+    public function setProxy($proxy);
 }


### PR DESCRIPTION
I needed the ability to select a proxy on a per-request level, so I made these changes to the curl driver. This is probably a bit of an edge case use, but I suppose others could benefit from it.

No tests, since I have no idea how to actually test this.