### PR TITLE
Workaround for faulty curl_getinfo implementation

### DIFF
--- a/lib/Buzz/Client/Curl.php
+++ b/lib/Buzz/Client/Curl.php
@@ -48,7 +48,7 @@ class Curl extends AbstractCurl
             throw new LogicException('There is no cURL resource');
         }
 
-        return curl_getinfo($this->lastCurl, $opt);
+        return 0 === $opt ? curl_getinfo($this->lastCurl) : curl_getinfo($this->lastCurl, $opt);
     }
 
     public function __destruct()


### PR DESCRIPTION
Suggested workaround for faulty curl_getinfo() function implementation on PHP side.

Current behaviour: `curl_getinfo($ch, 0)` returns `false`

Expected behaviour: `curl_getinfo($ch, 0)` returns same result as `curl_getinfo($ch)` (array of cURL response options).