### PR TITLE
Changed default protocol version to HTTP/1.1

### DIFF
--- a/lib/Buzz/Message/Request.php
+++ b/lib/Buzz/Message/Request.php
@@ -9,7 +9,7 @@ class Request extends AbstractMessage implements RequestInterface
     private $method;
     private $resource;
     private $host;
-    private $protocolVersion = 1.0;
+    private $protocolVersion = 1.1;
 
     /**
      * Constructor.

--- a/test/Buzz/Test/Client/AbstractStreamTest.php
+++ b/test/Buzz/Test/Client/AbstractStreamTest.php
@@ -32,7 +32,7 @@ class AbstractStreamTest extends \PHPUnit_Framework_TestCase
                 'method'           => 'POST',
                 'header'           => "Content-Type: application/x-www-form-urlencoded\r\nContent-Length: 15",
                 'content'          => 'foo=bar&bar=baz',
-                'protocol_version' => 1.0,
+                'protocol_version' => 1.1,
                 'ignore_errors'    => false,
                 'follow_location'  => true,
                 'max_redirects'    => 6,

--- a/test/Buzz/Test/Message/RequestTest.php
+++ b/test/Buzz/Test/Message/RequestTest.php
@@ -132,7 +132,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             'Content-Type: text/plain',
         ), $request->getHeaders());
 
-        $expected  = "GET / HTTP/1.0\r\n";
+        $expected  = "GET / HTTP/1.1\r\n";
         $expected .= "Cookie: foo=bar; bar=foo\r\n";
         $expected .= "Content-Type: text/plain\r\n";
 


### PR DESCRIPTION
This [issue](https://github.com/kriswallsmith/Buzz/issues/178) made a case for changing the default protocol version to HTTP/1.1.

The main point is that HTTP/1.0 doesn't support the 'Host' header and the library (and probably 99% of the use cases) rely on this header being present.