### PR TITLE
ask cURL to return the response header separated from the response body

### DIFF
--- a/lib/Buzz/Client/Curl.php
+++ b/lib/Buzz/Client/Curl.php
@@ -18,9 +18,15 @@ class Curl extends AbstractCurl
         }
 
         $this->lastCurl = static::createCurlHandle();
-        $this->prepare($this->lastCurl, $request, $options);
+        $file = fopen('php://memory', 'wt');
+        $this->prepare($this->lastCurl, $file, $request, $options);
 
         $data = curl_exec($this->lastCurl);
+
+        $len = ftell($file);
+        rewind($file);
+        $header = fread($file, $len);
+        fclose($file);
 
         if (false === $data) {
             $errorMsg = curl_error($this->lastCurl);
@@ -32,7 +38,7 @@ class Curl extends AbstractCurl
             throw $e;
         }
 
-        static::populateResponse($this->lastCurl, $data, $response);
+        static::populateResponse($header, $data, $response);
     }
 
     /**

--- a/lib/Buzz/Client/Curl.php
+++ b/lib/Buzz/Client/Curl.php
@@ -18,13 +18,17 @@ class Curl extends AbstractCurl
         }
 
         $this->lastCurl = static::createCurlHandle();
-        $file = fopen('php://memory', 'wt');
+        $file = fopen('php://memory', 'w+');
         $this->prepare($this->lastCurl, $file, $request, $options);
 
         $data = curl_exec($this->lastCurl);
 
         $len = ftell($file);
         rewind($file);
+        if (! $len) {
+            $stat = fstat($file);
+            $len = $stat['size'] ?: 65536;
+        }
         $header = fread($file, $len);
         fclose($file);
 

--- a/lib/Buzz/Client/MultiCurl.php
+++ b/lib/Buzz/Client/MultiCurl.php
@@ -67,7 +67,7 @@ class MultiCurl extends AbstractCurl implements BatchClientInterface
                 // remove custom option
                 unset($options['callback']);
 
-                $file = fopen('php://memory', 'wt');
+                $file = fopen('php://memory', 'w+');
                 $this->prepare($curl, $file, $request, $options);
                 $this->queue[$i][] = $curl;
                 $this->queue[$i][] = $file;
@@ -93,6 +93,10 @@ class MultiCurl extends AbstractCurl implements BatchClientInterface
                 // retrieve the header
                 $len = ftell($file);
                 rewind($file);
+                if (! $len) {
+                    $stat = fstat($file);
+                    $len = $stat['size'] ?: 65536;
+                }
                 $header = fread($file, $len);
                 fclose($file);
 


### PR DESCRIPTION
Another way to split the response header from the body is to ask cURL to do it (it probably does it behind the scene anyway).

* class `AbstractCurl`:
  - configured cURL to not include the headers into the returned response;
  - used `CURLOPT_WRITEHEADER` to ask cURL to write the header into a file;
  - `rtrim()` on `AbstractCurl::getLastHeaders()` is needed because the header returned this way ends with an empty line;
* updated the classes `Curl` and `MultiCurl` to use the new workflow; use in-memory streams for header files.