### PR TITLE
Add verify_host option

### DIFF
--- a/lib/Buzz/Client/AbstractClient.php
+++ b/lib/Buzz/Client/AbstractClient.php
@@ -8,6 +8,7 @@ abstract class AbstractClient implements ClientInterface
     protected $maxRedirects = 5;
     protected $timeout = 5;
     protected $verifyPeer = true;
+    protected $verifyHost = 2;
     protected $proxy;
 
     public function setIgnoreErrors($ignoreErrors)
@@ -48,6 +49,16 @@ abstract class AbstractClient implements ClientInterface
     public function getVerifyPeer()
     {
         return $this->verifyPeer;
+    }
+
+    public function getVerifyHost()
+    {
+        return $this->verifyHost;
+    }
+
+    public function setVerifyHost($verifyHost)
+    {
+        $this->verifyHost = $verifyHost;
     }
 
     public function setProxy($proxy)

--- a/lib/Buzz/Client/AbstractCurl.php
+++ b/lib/Buzz/Client/AbstractCurl.php
@@ -224,6 +224,7 @@ abstract class AbstractCurl extends AbstractClient
         curl_setopt($curl, CURLOPT_MAXREDIRS, $canFollow ? $this->getMaxRedirects() : 0);
         curl_setopt($curl, CURLOPT_FAILONERROR, !$this->getIgnoreErrors());
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->getVerifyPeer());
+        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, $this->getVerifyHost());
 
         // apply additional options
         curl_setopt_array($curl, $options + $this->options);

--- a/lib/Buzz/Client/AbstractStream.php
+++ b/lib/Buzz/Client/AbstractStream.php
@@ -31,6 +31,7 @@ abstract class AbstractStream extends AbstractClient
             ),
             'ssl' => array(
                 'verify_peer'      => $this->getVerifyPeer(),
+                'verify_host'      => $this->getVerifyHost(),
             ),
         );
 

--- a/test/Buzz/Test/Client/AbstractStreamTest.php
+++ b/test/Buzz/Test/Client/AbstractStreamTest.php
@@ -40,6 +40,7 @@ class AbstractStreamTest extends \PHPUnit_Framework_TestCase
             ),
             'ssl' => array(
                 'verify_peer'      => true,
+                'verify_host' => 2,
             ),
         );
 


### PR DESCRIPTION
This adds the verify_host option without the incorrect PHP_EOL and does not break previous  configurations.