### PR TITLE
AbstractCurl populateResponse fix

### DIFF
--- a/lib/Buzz/Client/AbstractCurl.php
+++ b/lib/Buzz/Client/AbstractCurl.php
@@ -55,16 +55,9 @@ abstract class AbstractCurl extends AbstractClient
      */
     protected static function populateResponse($curl, $raw, MessageInterface $response)
     {
-        // fixes bug https://sourceforge.net/p/curl/bugs/1204/
-        $version = curl_version();
-        if (version_compare($version['version'], '7.30.0', '<')) {
-            $pos = strlen($raw) - curl_getinfo($curl, CURLINFO_SIZE_DOWNLOAD);
-        } else {
-            $pos = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
-        }
-
-        $response->setHeaders(static::getLastHeaders(rtrim(substr($raw, 0, $pos))));
-        $response->setContent(strlen($raw) > $pos ? substr($raw, $pos) : '');
+        list($header, $body) = preg_split("/\R\R/", $raw, 2);
+        $response->setHeaders(static::getLastHeaders(rtrim($header)));
+        $response->setContent($body);
     }
 
     /**


### PR DESCRIPTION
Changed the logic for the populate response, splitting headers and body by double linebreak.

I found that in some requests, on different types of servers, sometimes body and headers are not correctly splitted. I found this post talking about how to solve it: http://stackoverflow.com/questions/8756185/how-to-isolate-the-http-headers-body-from-a-php-sockets-request/8756268#8756268. And I just replaced it in the populateResponse method.