### PR TITLE
Add support for listening for client exceptions

### DIFF
--- a/lib/Buzz/Browser.php
+++ b/lib/Buzz/Browser.php
@@ -11,6 +11,7 @@ use Buzz\Message\Factory\FactoryInterface;
 use Buzz\Message\MessageInterface;
 use Buzz\Message\RequestInterface;
 use Buzz\Util\Url;
+use Buzz\Listener\ExceptionListenerInterface;
 
 class Browser
 {
@@ -127,7 +128,14 @@ class Browser
             $this->listener->preSend($request);
         }
 
-        $this->client->send($request, $response);
+        try {
+            $this->client->send($request, $response);
+        } catch (\Exception $e) {
+            if ($this->listener && $this->listener instanceof ExceptionListenerInterface) {
+                $this->listener->onException($request, $e);
+            }
+            throw $e;
+        }
 
         $this->lastRequest = $request;
         $this->lastResponse = $response;

--- a/lib/Buzz/Listener/ExceptionListenerInterface.php
+++ b/lib/Buzz/Listener/ExceptionListenerInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Buzz\Listener;
+
+use Buzz\Listener\ListenerInterface;
+use Buzz\Message\RequestInterface;
+
+interface ExceptionListenerInterface extends ListenerInterface
+{
+    public function onException(RequestInterface $request, \Exception $exception);
+}

--- a/lib/Buzz/Listener/ListenerChain.php
+++ b/lib/Buzz/Listener/ListenerChain.php
@@ -2,10 +2,11 @@
 
 namespace Buzz\Listener;
 
+use Buzz\Listener\ExceptionListenerInterface;
 use Buzz\Message\MessageInterface;
 use Buzz\Message\RequestInterface;
 
-class ListenerChain implements ListenerInterface
+class ListenerChain implements ListenerInterface, ExceptionListenerInterface
 {
     private $listeners;
 
@@ -35,6 +36,15 @@ class ListenerChain implements ListenerInterface
     {
         foreach ($this->listeners as $listener) {
             $listener->postSend($request, $response);
+        }
+    }
+
+    public function onException(RequestInterface $request, \Exception $exception)
+    {
+        foreach ($this->listeners as $listener) {
+            if ($listener instanceof ExceptionListenerInterface) {
+                $listener->onException($request, $exception);
+            }
         }
     }
 }

--- a/test/Buzz/Test/BrowserTest.php
+++ b/test/Buzz/Test/BrowserTest.php
@@ -121,6 +121,38 @@ class BrowserTest extends \PHPUnit_Framework_TestCase
         $this->browser->send($request, $response);
     }
 
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage testExceptionListener
+     */
+    public function testExceptionListener()
+    {
+        $listener = $this->getMock('Buzz\Listener\ExceptionListenerInterface');
+        $request = $this->getMock('Buzz\Message\RequestInterface');
+        $response = $this->getMock('Buzz\Message\MessageInterface');
+        $exception = new \Exception('testExceptionListener');
+
+        $client = $this->getMock('Buzz\Client\ClientInterface');
+        $client->expects($this->once())
+            ->method('send')
+            ->will($this->returnCallback(function () use ($exception) {
+                throw $exception;
+            }));
+        $browser = new Browser($client, $this->factory);
+
+        $listener->expects($this->once())
+            ->method('preSend')
+            ->with($request);
+        $listener->expects($this->once())
+            ->method('onException')
+            ->with($request, $exception);
+
+        $browser->setListener($listener);
+        $this->assertSame($listener, $browser->getListener());
+
+        $browser->send($request, $response);
+    }
+
     public function testLastMessages()
     {
         $request = $this->getMock('Buzz\Message\RequestInterface');

--- a/test/Buzz/Test/Listener/ListenerChainTest.php
+++ b/test/Buzz/Test/Listener/ListenerChainTest.php
@@ -33,4 +33,23 @@ class ListenerChainTest extends \PHPUnit_Framework_TestCase
         $listener->preSend($request);
         $listener->postSend($request, $response);
     }
+
+    public function testChainWithException()
+    {
+        $delegate = $this->getMock('Buzz\Listener\ExceptionListenerInterface');
+        $request = new Message\Request();
+        $response = new Message\Response();
+        $exception = new \Exception();
+
+        $delegate->expects($this->once())
+            ->method('preSend')
+            ->with($request);
+        $delegate->expects($this->once())
+            ->method('onException')
+            ->with($request, $exception);
+
+        $listener = new ListenerChain(array($delegate));
+        $listener->preSend($request);
+        $listener->onException($request, $exception);
+    }
 }


### PR DESCRIPTION
This fixes #212.

Adds a ExceptionListenerInterface. When an exception is thrown during client->send(), Browser calls listener->onException() if the listener implements ExceptionListenerInterface.
