### PR TITLE
Fix throwing MultiCurl errors

### DIFF
--- a/lib/Buzz/Client/MultiCurl.php
+++ b/lib/Buzz/Client/MultiCurl.php
@@ -92,14 +92,12 @@ class MultiCurl extends AbstractCurl implements BatchClientInterface
                 // populate the response object
                 if (CURLE_OK === $done['result']) {
                     static::populateResponse($curl, curl_multi_getcontent($curl), $response);
-                } else {
+                } else if (!isset($e)) {
                     $errorMsg = curl_error($curl);
                     $errorNo  = curl_errno($curl);
 
                     $e = new RequestException($errorMsg, $errorNo);
                     $e->setRequest($request);
-
-                    throw $e;
                 }
 
                 // remove from queue
@@ -118,6 +116,10 @@ class MultiCurl extends AbstractCurl implements BatchClientInterface
         if (!$this->queue) {
             curl_multi_close($this->curlm);
             $this->curlm = null;
+        }
+
+        if (isset($e)) {
+            throw $e;
         }
     }
 }

--- a/lib/Buzz/Client/MultiCurl.php
+++ b/lib/Buzz/Client/MultiCurl.php
@@ -2,6 +2,7 @@
 
 namespace Buzz\Client;
 
+use Buzz\Exception\RequestException;
 use Buzz\Message\MessageInterface;
 use Buzz\Message\RequestInterface;
 use Buzz\Exception\ClientException;
@@ -91,6 +92,14 @@ class MultiCurl extends AbstractCurl implements BatchClientInterface
                 // populate the response object
                 if (CURLE_OK === $done['result']) {
                     static::populateResponse($curl, curl_multi_getcontent($curl), $response);
+                } else {
+                    $errorMsg = curl_error($curl);
+                    $errorNo  = curl_errno($curl);
+
+                    $e = new RequestException($errorMsg, $errorNo);
+                    $e->setRequest($request);
+
+                    throw $e;
                 }
 
                 // remove from queue


### PR DESCRIPTION
Hi,
Using the Curl client, Buzz correctly throws any errors returned by Curl with a RequestException. But with MultiCurl, it was not the case. This PR fixes this behaviour by throwing the first error that (Multi)Curl may get.

It is the responsibility of the Buzz users to catch or ignore these errors, and Buzz should not ignore them directly.
