### PR TITLE
Improvement : added reuseLastConnection to avoid close then create Curl HTTP/HTTPS connection before each request

### DIFF
--- a/lib/Buzz/Client/AbstractCurl.php
+++ b/lib/Buzz/Client/AbstractCurl.php
@@ -14,6 +14,7 @@ use Buzz\Exception\ClientException;
 abstract class AbstractCurl extends AbstractClient
 {
     protected $options = array();
+	protected $reuseLastConnection = false;
 
     public function __construct()
     {
@@ -229,4 +230,14 @@ abstract class AbstractCurl extends AbstractClient
         // apply additional options
         curl_setopt_array($curl, $options + $this->options);
     }
+	
+    public function setReuseLastConnection($reuseLastConnection)
+    {
+        $this->reuseLastConnection = $reuseLastConnection;
+    }
+
+    public function getReuseLastConnection()
+    {
+        return $this->reuseLastConnection;
+    }	
 }

--- a/lib/Buzz/Client/Curl.php
+++ b/lib/Buzz/Client/Curl.php
@@ -13,12 +13,13 @@ class Curl extends AbstractCurl
 
     public function send(RequestInterface $request, MessageInterface $response, array $options = array())
     {
-        if (is_resource($this->lastCurl)) {
-            curl_close($this->lastCurl);
-        }
-
-        $this->lastCurl = static::createCurlHandle();
-        $this->prepare($this->lastCurl, $request, $options);
+		if (!$this->reuseLastConnection && is_resource($this->lastCurl))
+			curl_close($this->lastCurl);
+		
+		if (!$this->reuseLastConnection || !is_resource($this->lastCurl))
+			$this->lastCurl = static::createCurlHandle();
+        
+		$this->prepare($this->lastCurl, $request, $options);
 
         $data = curl_exec($this->lastCurl);
 


### PR DESCRIPTION
Hello,

It's my first contirbution on Github, so I hope I'm doing it the right way ;)

I added a new setting "reuseLastConnection" in AbstractCurl.php to avoid close then create Curl HTTP/HTTPS connection before each request. This permit to improve performance and network usage when doing multiple request to the same website or webservice

Usage :
		$curl = new Buzz\Client\Curl();
		$curl->setReuseLastConnection(true);

Thanks
Ahmad BARRIN