### PR TITLE
Introduce CURLOPT_POSTREDIR option for missing request body when following 301 redirects

### DIFF
--- a/lib/Buzz/Client/AbstractCurl.php
+++ b/lib/Buzz/Client/AbstractCurl.php
@@ -224,10 +224,11 @@ abstract class AbstractCurl extends AbstractClient
         }
 
         $canFollow = !ini_get('safe_mode') && !ini_get('open_basedir');
+        $postAll = defined('CURL_REDIR_POST_ALL') ? CURL_REDIR_POST_ALL : 7;
 
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, $canFollow && $this->getMaxRedirects() > 0);
         curl_setopt($curl, CURLOPT_MAXREDIRS, $canFollow ? $this->getMaxRedirects() : 0);
-        curl_setopt($curl, CURLOPT_POSTREDIR, $canFollow ? CURL_REDIR_POST_ALL : 0);
+        curl_setopt($curl, CURLOPT_POSTREDIR, $canFollow ? $postAll : 0);
         curl_setopt($curl, CURLOPT_FAILONERROR, !$this->getIgnoreErrors());
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->getVerifyPeer());
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, $this->getVerifyHost());

--- a/lib/Buzz/Client/AbstractCurl.php
+++ b/lib/Buzz/Client/AbstractCurl.php
@@ -227,6 +227,7 @@ abstract class AbstractCurl extends AbstractClient
 
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, $canFollow && $this->getMaxRedirects() > 0);
         curl_setopt($curl, CURLOPT_MAXREDIRS, $canFollow ? $this->getMaxRedirects() : 0);
+        curl_setopt($curl, CURLOPT_POSTREDIR, $canFollow ? CURL_REDIR_POST_ALL : 0);
         curl_setopt($curl, CURLOPT_FAILONERROR, !$this->getIgnoreErrors());
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->getVerifyPeer());
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, $this->getVerifyHost());


### PR DESCRIPTION
Buzz is following 301 redirects because of CURLOPT_FOLLOWLOCATION, but the request body is missing in the subsequent requests. CURLOPT_FOLLOWLOCATION switches from POST to GET requests, so the POST body is lost due to the default [CURLOPT_POSTREDIR](https://curl.haxx.se/libcurl/c/CURLOPT_POSTREDIR.html) setting.

A library I'm using [(opensearchserver-php-client)](https://github.com/jaeksoft/opensearchserver-php-client) gets a HTTP/1.1 200 OK answer that looks normal but is missing the needed result fields which is inexplicable behaviour.

I made this PR to introduce the CURLOPT_POSTREDIR setting that solves this. Is this ok or should this be configurable by an option?