### PR TITLE
Adding request/response converter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ matrix:
           dist: trusty
     fast_finish: true
     include:
-        - php: 5.3
-          dist: precise
         - php: 5.5
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": "^5.3.3 || ^7.0"
+        "php": "^5.3.3 || ^7.0",
+        "guzzlehttp/psr7": "^1.4"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^3.3"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^5.3.3 || ^7.0",
+        "php": "^5.4 || ^7.0",
         "guzzlehttp/psr7": "^1.4"
     },
     "require-dev": {

--- a/lib/Buzz/Converter/HeaderConverter.php
+++ b/lib/Buzz/Converter/HeaderConverter.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buzz\Converter;
+
+/**
+ * Convert between Buzz style:
+ * array(
+ *   'foo: bar',
+ *   'baz: biz',
+ * )
+ *
+ * and PSR style:
+ * array(
+ *   'foo' => 'bar'
+ *   'baz' => ['biz', 'buz'],
+ * )
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class HeaderConverter
+{
+    /**
+     * Convert from Buzz style headers to PSR style
+     * @param array $headers
+     *
+     * @return array
+     */
+    public static function toBuzzHeaders(array $headers)
+    {
+        $buzz = [];
+
+        foreach ($headers as $key => $values) {
+            if (!is_array($values)) {
+                $buzz[] = sprintf('%s: %s', $key, $values);
+            } else {
+                foreach ($values as $value) {
+                    $buzz[] = sprintf('%s: %s', $key, $value);
+                }
+            }
+        }
+
+        return $buzz;
+    }
+
+    /**
+     * Convert from PSR style headers to Buzz style
+     * @param array $headers
+     * @return array
+     */
+    public static function toPsrHeaders(array $headers)
+    {
+        $psr = [];
+        foreach ($headers as $header) {
+            list($key, $value) = explode(':', $header, 2);
+            $psr[trim($key)][] = trim($value);
+        }
+
+        return $psr;
+    }
+}

--- a/lib/Buzz/Converter/RequestConverter.php
+++ b/lib/Buzz/Converter/RequestConverter.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Buzz\Converter;
+
+use Buzz\Exception\LogicException;
+use Buzz\Message\Request;
+use Buzz\Message\RequestInterface;
+use Psr\Http\Message\RequestInterface as Psr7RequestInterface;
+
+class RequestConverter
+{
+    /**
+     * @param Psr7RequestInterface|RequestInterface $request
+     * @return Psr7RequestInterface
+     */
+    public static function psr7($request)
+    {
+        if ($request instanceof Psr7RequestInterface) {
+            return $request;
+        } elseif (!$request instanceof RequestInterface) {
+            throw new LogicException('Only instances of PSR7 Request and Buzz requests are allowed');
+        }
+
+        // Convert the response to psr7
+        return new \GuzzleHttp\Psr7\Request(
+            $request->getMethod(),
+            sprintf('%s://%s%s', $request->isSecure() ? 'https': 'http', $request->getHost(), $request->getResource()),
+            $request->getHeaders(),
+            $request->getContent(),
+            $request->getProtocolVersion()
+        );
+    }
+    /**
+     * @param Psr7RequestInterface|RequestInterface $request
+     * @return RequestInterface
+     */
+    public static function buzz($request)
+    {
+        if ($request instanceof RequestInterface) {
+            return $request;
+        } elseif (!$request instanceof Psr7RequestInterface) {
+            throw new LogicException('Only instances of PSR7 Request and Buzz requests are allowed');
+        }
+
+        // Convert the response to buzz response
+        $uri = $request->getUri();
+        $buzzRequest = new Request(
+            $request->getMethod(),
+            sprintf('%s?%s', $uri->getPath(), $uri->getQuery()),
+            $uri->getHost()
+        );
+
+        $buzzRequest->addHeaders($request->getHeaders());
+        $buzzRequest->setContent($request->getBody()->__toString());
+        $buzzRequest->setProtocolVersion($request->getProtocolVersion());
+
+        return $buzzRequest;
+    }
+}

--- a/lib/Buzz/Converter/RequestConverter.php
+++ b/lib/Buzz/Converter/RequestConverter.php
@@ -7,6 +7,11 @@ use Buzz\Message\Request;
 use Buzz\Message\RequestInterface;
 use Psr\Http\Message\RequestInterface as Psr7RequestInterface;
 
+/**
+ *
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
 class RequestConverter
 {
     /**
@@ -25,7 +30,7 @@ class RequestConverter
         return new \GuzzleHttp\Psr7\Request(
             $request->getMethod(),
             sprintf('%s://%s%s', $request->isSecure() ? 'https': 'http', $request->getHost(), $request->getResource()),
-            $request->getHeaders(),
+            HeaderConverter::toPsrHeaders($request->getHeaders()),
             $request->getContent(),
             $request->getProtocolVersion()
         );
@@ -50,7 +55,7 @@ class RequestConverter
             $uri->getHost()
         );
 
-        $buzzRequest->addHeaders($request->getHeaders());
+        $buzzRequest->addHeaders(HeaderConverter::toBuzzHeaders($request->getHeaders()));
         $buzzRequest->setContent($request->getBody()->__toString());
         $buzzRequest->setProtocolVersion($request->getProtocolVersion());
 

--- a/lib/Buzz/Converter/ResponseConverter.php
+++ b/lib/Buzz/Converter/ResponseConverter.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Buzz\Converter;
+
+use Buzz\Exception\LogicException;
+use Buzz\Message\Response;
+use Psr\Http\Message\ResponseInterface;
+
+class ResponseConverter
+{
+    /**
+     * @param ResponseInterface|Response $response
+     * @return ResponseInterface
+     */
+    public static function psr7($response)
+    {
+        if ($response instanceof ResponseInterface) {
+            return $response;
+        } elseif (!$response instanceof Response) {
+            throw new LogicException('Only instances of PSR7 Response and Buzz responses are allowed');
+        }
+
+        // Convert the response to psr7
+        return new \GuzzleHttp\Psr7\Response(
+            $response->getStatusCode(),
+            $response->getHeaders(),
+            $response->getContent(),
+            $response->getProtocolVersion(),
+            $response->getReasonPhrase()
+        );
+    }
+    /**
+     * @param ResponseInterface|Response $response
+     * @return Response
+     */
+    public static function buzz($response)
+    {
+        if ($response instanceof Response) {
+            return $response;
+        } elseif (!$response instanceof ResponseInterface) {
+            throw new LogicException('Only instances of PSR7 Response and Buzz responses are allowed');
+        }
+
+        // Convert the response to buzz response
+        $headers = $response->getHeaders();
+        array_unshift($headers, sprintf('HTTP/%s %d %s', $response->getProtocolVersion(), $response->getStatusCode(), $response->getReasonPhrase()));
+
+        $buzzResponse = new Response();
+        $buzzResponse->addHeaders($headers);
+        $buzzResponse->setContent($response->getBody()->__toString());
+
+        return $buzzResponse;
+    }
+}

--- a/lib/Buzz/Converter/ResponseConverter.php
+++ b/lib/Buzz/Converter/ResponseConverter.php
@@ -6,6 +6,11 @@ use Buzz\Exception\LogicException;
 use Buzz\Message\Response;
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ *
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
 class ResponseConverter
 {
     /**
@@ -21,9 +26,13 @@ class ResponseConverter
         }
 
         // Convert the response to psr7
+        $headers = $response->getHeaders();
+        // Remove status line
+        array_shift($headers);
+
         return new \GuzzleHttp\Psr7\Response(
             $response->getStatusCode(),
-            $response->getHeaders(),
+            HeaderConverter::toPsrHeaders($headers),
             $response->getContent(),
             $response->getProtocolVersion(),
             $response->getReasonPhrase()
@@ -42,7 +51,7 @@ class ResponseConverter
         }
 
         // Convert the response to buzz response
-        $headers = $response->getHeaders();
+        $headers =HeaderConverter::toBuzzHeaders($response->getHeaders());
         array_unshift($headers, sprintf('HTTP/%s %d %s', $response->getProtocolVersion(), $response->getStatusCode(), $response->getReasonPhrase()));
 
         $buzzResponse = new Response();

--- a/test/Buzz/Test/Converter/RequestConverterTest.php
+++ b/test/Buzz/Test/Converter/RequestConverterTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Buzz\Test\Converter;
+
+use Buzz\Converter\RequestConverter;
+use Buzz\Message\Request;
+use PHPUnit\Framework\TestCase;
+
+class RequestConverterTest extends TestCase
+{
+    public function testPsr7()
+    {
+        $buzz = new Request(Request::METHOD_GET, '/foo', 'example.com');
+        $buzz->setContent('Foobar');
+
+        $psr = RequestConverter::psr7($buzz);
+        $this->assertEquals('GET', $psr->getMethod());
+        $this->assertEquals('/foo', $psr->getUri()->getPath());
+        $this->assertEquals('example.com', $psr->getUri()->getHost());
+        $this->assertEquals('Foobar', $psr->getBody()->__toString());
+    }
+    public function testBuzz()
+    {
+        $psr = new \GuzzleHttp\Psr7\Request('GET', 'https://example.com/foo?bar', ['header'=>'value'], 'Body');
+
+        $buzz = RequestConverter::buzz($psr);
+        $this->assertEquals('GET', $buzz->getMethod());
+        $this->assertEquals('/foo?bar', $buzz->getResource());
+        $this->assertEquals('example.com', $buzz->getHost());
+        $this->assertEquals('Foobar', $buzz->getContent());
+    }
+}

--- a/test/Buzz/Test/Converter/RequestConverterTest.php
+++ b/test/Buzz/Test/Converter/RequestConverterTest.php
@@ -21,7 +21,7 @@ class RequestConverterTest extends TestCase
     }
     public function testBuzz()
     {
-        $psr = new \GuzzleHttp\Psr7\Request('GET', 'https://example.com/foo?bar', ['header'=>'value'], 'Body');
+        $psr = new \GuzzleHttp\Psr7\Request('GET', 'https://example.com/foo?bar', ['header'=>'value'], 'Foobar');
 
         $buzz = RequestConverter::buzz($psr);
         $this->assertEquals('GET', $buzz->getMethod());

--- a/test/Buzz/Test/Converter/ResponseConverterTest.php
+++ b/test/Buzz/Test/Converter/ResponseConverterTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Buzz\Test\Converter;
+
+use Buzz\Converter\RequestConverter;
+use Buzz\Converter\ResponseConverter;
+use Buzz\Message\Request;
+use Buzz\Message\Response;
+use PHPUnit\Framework\TestCase;
+
+class ResponseConverterTest extends TestCase
+{
+    public function testPsr7()
+    {
+        $buzz = new Response();
+        $buzz->addHeader('HTTP/1.0 200 OK');
+        $buzz->addHeader('Content-Type: text/html');
+        $buzz->setContent('Foobar');
+
+        $psr = ResponseConverter::psr7($buzz);
+        $this->assertEquals('1.0', $psr->getProtocolVersion());
+        $this->assertEquals('OK', $psr->getReasonPhrase());
+        $this->assertEquals('200', $psr->getStatusCode());
+        $this->assertEquals('Foobar', $psr->getBody()->__toString());
+        $this->assertEquals('text/html', $psr->getHeaderLine('Content-Type'));
+    }
+
+
+    public function testBuzz()
+    {
+        $psr = new \GuzzleHttp\Psr7\Response(
+            200,
+            ['content-type'=>'text/html'],
+            'Foobar',
+            '1.1',
+            'OK'
+        );
+
+        $buzz = ResponseConverter::buzz($psr);
+        $this->assertEquals('200', $buzz->getStatusCode());
+        $this->assertEquals('1.1', $buzz->getProtocolVersion());
+        $this->assertEquals('OK', $buzz->getReasonPhrase());
+        $this->assertEquals('Foobar', $buzz->getContent());
+        $this->assertEquals('text/html', $buzz->getHeader('Content-type'));
+    }
+}


### PR DESCRIPTION
In the journey towards PSR7 support we should have converters that converts between Buzz requests/responses to PSR7. 

This PR adds such converters. 