### PR TITLE
Do not parse options if array is empty

### DIFF
--- a/lib/Buzz/Client/AbstractClient.php
+++ b/lib/Buzz/Client/AbstractClient.php
@@ -22,8 +22,8 @@ abstract class AbstractClient
 
     public function __construct(array $options = [])
     {
-        $this->options = new ParameterBag($options);
-        $this->validateOptions();
+        $this->options = new ParameterBag();
+        $this->options = $this->doValidateOptions($options);
     }
 
     protected function getOptionsResolver()
@@ -42,6 +42,18 @@ abstract class AbstractClient
      * Validate a set of options and return a new and shiny ParameterBag.
      */
     protected function validateOptions(array $options = []): ParameterBag
+    {
+        if (empty($options)) {
+            return $this->options;
+        }
+
+        return $this->doValidateOptions($options);
+    }
+
+    /**
+     * Validate a set of options and return a new and shiny ParameterBag.
+     */
+    private function doValidateOptions(array $options = []): ParameterBag
     {
         $parameterBag = $this->options->add($options);
         try {


### PR DESCRIPTION
A minor performance boost when you do not use any extra options. 

<img width="325" alt="screen shot 2018-03-24 at 10 08 52" src="https://user-images.githubusercontent.com/1275206/37862334-72f1631a-2f4b-11e8-806e-0857f972c8d6.png">
