### PR TITLE
Make our options and API more similar to Guzzle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The change log shows what have been Added, Changed, Deprecated and Removed betwe
 - Redirects are not followed by default
 - No exceptions are thrown and no warnings are triggered on a invalid response. 
 - We only handle PSR requests and responses. 
+- Renamed `Browser::call($url, $method, $headers, $body)` to `Browser::request($method, $url, $headers, $body)`. 
 
 ## 0.16.1
 

--- a/doc/client.md
+++ b/doc/client.md
@@ -18,6 +18,13 @@ $response = $client->send($request, ['timeout' => 4]);
 Not all configuration works will all clients. If there is any client specific configuration it 
 will be noted below. 
 
+#### allow_redirects
+
+Type: boolean<br>
+Default: `false`
+
+Should the client follow HTTP redirects or not. 
+
 #### Callback
 
 Type: callable<br>
@@ -48,13 +55,6 @@ $client->sendAsyncRequest($request, array('curl' => [
     CURLOPT_FAILONERROR => false,
 ]));
 ```
-
-#### allow_redirects
-
-Type: boolean<br>
-Default: `false`
-
-Should the client follow HTTP redirects or not. 
 
 #### max_redirects
 

--- a/doc/client.md
+++ b/doc/client.md
@@ -9,7 +9,7 @@ There are 3 clients: `FileGetContents`, `Curl` and `MultiCurl`.
 ```php
 $request = new PSR7Request('GET', 'https://example.com');
 
-$client = new Buzz\Client\FileGetContents(['follow_redirects'=>true]);
+$client = new Buzz\Client\FileGetContents(['allow_redirects'=>true]);
 $response = $client->send($request, ['timeout' => 4]);
 ```
 
@@ -49,7 +49,7 @@ $client->sendAsyncRequest($request, array('curl' => [
 ]));
 ```
 
-#### follow_redirects
+#### allow_redirects
 
 Type: boolean<br>
 Default: `false`
@@ -77,12 +77,9 @@ Default: `30`
 
 The time to wait before interrupt the request. 
 
-#### verify_host
+#### verify
 
 Type: boolean<br>
 Default: `true`
 
-#### verify_peer
-
-Type: boolean<br>
-Default: `true`
+If SSL protocols should verified. 

--- a/lib/Browser.php
+++ b/lib/Browser.php
@@ -42,45 +42,45 @@ class Browser implements BuzzClientInterface
 
     public function get(string $url, array $headers = []): ResponseInterface
     {
-        return $this->call($url, 'GET', $headers);
+        return $this->request('GET', $url, $headers);
     }
 
     public function post(string $url, array $headers = [], string $body = ''): ResponseInterface
     {
-        return $this->call($url, 'POST', $headers, $body);
+        return $this->request('POST', $url, $headers, $body);
     }
 
     public function head(string $url, array  $headers = []): ResponseInterface
     {
-        return $this->call($url, 'HEAD', $headers);
+        return $this->request('HEAD', $url, $headers);
     }
 
     public function patch(string $url, array  $headers = [], string $body = ''): ResponseInterface
     {
-        return $this->call($url, 'PATCH', $headers, $body);
+        return $this->request('PATCH', $url, $headers, $body);
     }
 
     public function put(string $url, array  $headers = [], string $body = ''): ResponseInterface
     {
-        return $this->call($url, 'PUT', $headers, $body);
+        return $this->request('PUT', $url, $headers, $body);
     }
 
     public function delete(string $url, array  $headers = [], string $body = ''): ResponseInterface
     {
-        return $this->call($url, 'DELETE', $headers, $body);
+        return $this->request('DELETE', $url, $headers, $body);
     }
 
     /**
      * Sends a request.
      *
-     * @param string $url     The URL to call
      * @param string $method  The request method to use
+     * @param string $url     The URL to call
      * @param array  $headers An array of request headers
      * @param string $body    The request content
      *
      * @return ResponseInterface The response object
      */
-    public function call(string $url, string $method, array $headers = [], string $body = ''): ResponseInterface
+    public function request(string $method, string $url, array $headers = [], string $body = ''): ResponseInterface
     {
         $request = $this->getMessageFactory()->createRequest($method, $url, $headers, $body);
 

--- a/lib/Client/AbstractClient.php
+++ b/lib/Client/AbstractClient.php
@@ -69,17 +69,15 @@ abstract class AbstractClient
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'follow_redirects' => false,
+            'allow_redirects' => false,
             'max_redirects' => 5,
             'timeout' => 30,
-            'verify_peer' => true,
-            'verify_host' => true,
+            'verify' => true,
             'proxy' => null,
         ]);
 
-        $resolver->setAllowedTypes('follow_redirects', 'boolean');
-        $resolver->setAllowedTypes('verify_peer', 'boolean');
-        $resolver->setAllowedTypes('verify_host', 'boolean');
+        $resolver->setAllowedTypes('allow_redirects', 'boolean');
+        $resolver->setAllowedTypes('verify', 'boolean');
         $resolver->setAllowedTypes('max_redirects', 'integer');
         $resolver->setAllowedTypes('timeout', ['integer', 'float']);
         $resolver->setAllowedTypes('proxy', ['null', 'string']);

--- a/lib/Client/AbstractCurl.php
+++ b/lib/Client/AbstractCurl.php
@@ -193,11 +193,11 @@ abstract class AbstractCurl extends AbstractClient
             curl_setopt($curl, CURLOPT_PROXY, $proxy);
         }
 
-        $canFollow = !ini_get('safe_mode') && !ini_get('open_basedir') && $options->get('follow_redirects');
+        $canFollow = !ini_get('safe_mode') && !ini_get('open_basedir') && $options->get('allow_redirects');
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, $canFollow);
         curl_setopt($curl, CURLOPT_MAXREDIRS, $canFollow ? $options->get('max_redirects') : 0);
-        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $options->get('verify_peer') ? 1 : 0);
-        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, $options->get('verify_host') ? 2 : 0);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $options->get('verify') ? 1 : 0);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, $options->get('verify') ? 2 : 0);
         curl_setopt($curl, CURLOPT_TIMEOUT, $timeout);
     }
 

--- a/lib/Client/FileGetContents.php
+++ b/lib/Client/FileGetContents.php
@@ -62,7 +62,7 @@ class FileGetContents extends AbstractClient implements BuzzClientInterface
             ],
             'ssl' => [
                 'verify_peer' => $options->get('verify'),
-                'verify_host' => $options->get('verify') ? 2 : 0,
+                'verify_host' => $options->get('verify'),
             ],
         ];
 

--- a/lib/Client/FileGetContents.php
+++ b/lib/Client/FileGetContents.php
@@ -62,7 +62,7 @@ class FileGetContents extends AbstractClient implements BuzzClientInterface
             ],
             'ssl' => [
                 'verify_peer' => $options->get('verify'),
-                'verify_host' => $options->get('verify'),
+                'verify_host' => $options->get('verify') ? 2 : 0,
             ],
         ];
 

--- a/lib/Client/FileGetContents.php
+++ b/lib/Client/FileGetContents.php
@@ -56,13 +56,13 @@ class FileGetContents extends AbstractClient implements BuzzClientInterface
 
                 // values from the current client
                 'ignore_errors' => true,
-                'follow_location' => $options->get('follow_redirects') && $options->get('max_redirects') > 0,
+                'follow_location' => $options->get('allow_redirects') && $options->get('max_redirects') > 0,
                 'max_redirects' => $options->get('max_redirects') + 1,
                 'timeout' => $options->get('timeout'),
             ],
             'ssl' => [
-                'verify_peer' => $options->get('verify_peer'),
-                'verify_host' => $options->get('verify_host'),
+                'verify_peer' => $options->get('verify'),
+                'verify_host' => $options->get('verify'),
             ],
         ];
 

--- a/tests/Unit/Client/FileGetContentsTest.php
+++ b/tests/Unit/Client/FileGetContentsTest.php
@@ -53,8 +53,9 @@ class FileGetContentsTest extends TestCase
         ]);
         $this->assertEquals($expected, $client->getStreamContextArray($request, $options));
 
-        $options = $options->add(['verify_peer' => false]);
+        $options = $options->add(['verify' => false]);
         $expected['ssl']['verify_peer'] = false;
+        $expected['ssl']['verify_host'] = 0;
         $this->assertEquals($expected, $client->getStreamContextArray($request, $options));
 
         $options = $options->add(['max_redirects' => 0]);

--- a/tests/Unit/Client/FileGetContentsTest.php
+++ b/tests/Unit/Client/FileGetContentsTest.php
@@ -55,7 +55,7 @@ class FileGetContentsTest extends TestCase
 
         $options = $options->add(['verify' => false]);
         $expected['ssl']['verify_peer'] = false;
-        $expected['ssl']['verify_host'] = 0;
+        $expected['ssl']['verify_host'] = false;
         $this->assertEquals($expected, $client->getStreamContextArray($request, $options));
 
         $options = $options->add(['max_redirects' => 0]);

--- a/tests/Unit/Client/FileGetContentsTest.php
+++ b/tests/Unit/Client/FileGetContentsTest.php
@@ -48,9 +48,8 @@ class FileGetContentsTest extends TestCase
         $options = new ParameterBag([
             'max_redirects' => 5,
             'timeout' => 10,
-            'follow_redirects' => true,
-            'verify_peer' => true,
-            'verify_host' => true,
+            'allow_redirects' => true,
+            'verify' => true,
         ]);
         $this->assertEquals($expected, $client->getStreamContextArray($request, $options));
 


### PR DESCRIPTION
Renamed options: 
- `follow_redirects` => `allow_redirects`
- `verify_host` => `verify`
- `verify_peer` => `verify`


Also updated `Browser::call` => `Browser::request`.


These changes are made to be more similar to guzzle. This would make it easier to change between the two clients. 

FYI @tarlepp 