### PR TITLE
chore: remove that 0.17.0 isn't released, it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The change log shows what have been Added, Changed, Deprecated and Removed between versions. 
 
-## 0.17.0 (Not released)
+## 0.17.0
 
 ### Added
 


### PR DESCRIPTION
We noticed our CI broke 5 hours ago~ as we had some older code using the BuzzBundle from Sensio. Followed the breakcrumbs to here, I see the changelog is wrong though.

I also see this PR needs merged ideally also
https://github.com/sensiolabs/SensioBuzzBundle/pull/28