### PR TITLE
chore: remove the quotes of semver as this package isn't released

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,6 @@ We do love PSRs and this is a wish list of what PSR we would like to support:
 * PSR-17 (HTTP factories)
 * PSR-18 (HTTP client)
 
-## Backwards Compatibility Promise
-
-We take backwards compatibility very seriously as you should do with any open source project. We strictly follow [Semver](http://semver.org/).
-Please note that Semver works a bit different prior version 1.0.0. Minor versions prior 1.0.0 are allow to break backwards
-compatibility. 
-
-Being greatly inspired by [Symfony's bc promise](https://symfony.com/doc/current/contributing/code/bc.html), we have adopted
-their method of deprecating classes, interfaces and functions. 
-
 ## Running the tests
 
 To run the test we need to set up a webserver. Using PHP's build in one works perfectly. 


### PR DESCRIPTION
> Major version zero (0.y.z) is for initial development. Anything may change at any time. The public API should not be considered stable.

As per semver, until this package has tagged a `1.0.0` there isn't much use in this section of readme, its more confusing to have than anything in light of the recent breaking change from `0.16.1` to `0.17.0` while this didn't break semver due to non major its abit redundant. 

It would be nice to have a `1.0.0` tagged at some point, the package is 8 years old.. Im sure people would like semver to be implemented 