### PR TITLE
middlewares-doc typo fixed: extends -> implements

### DIFF
--- a/doc/middlewares.md
+++ b/doc/middlewares.md
@@ -26,7 +26,7 @@ First we need to create a class that implements `Buzz\Middleware\MiddlewareInter
 
 use Buzz\Middleware\MiddlewareInterface;
 
-class UserAgentMiddleware extends MiddlewareInterface 
+class UserAgentMiddleware implements MiddlewareInterface 
 {
   // ...
 ``` 
@@ -70,7 +70,7 @@ use Buzz\Middleware\MiddlewareInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-class UserAgentMiddleware extends MiddlewareInterface 
+class UserAgentMiddleware implements MiddlewareInterface 
 {
   public function handleRequest(RequestInterface $request, callable $next)
   {


### PR DESCRIPTION
### Summary
Found a typo in the documentation.  

### Fixed/Changed
Implementing the Interface instead of extending it (in the code-samples)