### PR TITLE
Make it possible to supply your own MessageFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The change log shows what have been Added, Changed, Deprecated and Removed between versions. 
 
+## 0.17.2
+
+### Changed
+
+- Added `ResponseFactory` to `AbstractClient` options
+- Added `RequestFactory` to `Browser` options
+
 ## 0.17.1
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "psr/http-client": "^0.1",
         "php-http/httplug": "^1.1",
         "nyholm/psr7": "^0.3",
-        "symfony/options-resolver": "^3.4 || ^4.0"
+        "symfony/options-resolver": "^3.4 || ^4.0",
+        "http-interop/http-factory": "^0.3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.11",

--- a/lib/Browser.php
+++ b/lib/Browser.php
@@ -11,7 +11,7 @@ use Buzz\Exception\InvalidArgumentException;
 use Buzz\Exception\LogicException;
 use Buzz\Middleware\MiddlewareInterface;
 use Http\Message\RequestFactory;
-use \Http\Message\MessageFactory as MessageFactoryInterface;
+use Http\Message\MessageFactory as MessageFactoryInterface;
 use Interop\Http\Factory\RequestFactoryInterface;
 use Nyholm\Psr7\Factory\MessageFactory;
 use Psr\Http\Message\RequestInterface;

--- a/lib/Browser.php
+++ b/lib/Browser.php
@@ -50,8 +50,11 @@ class Browser implements BuzzClientInterface
         $responseFactory = null
     ) {
         $this->client = $client ?: new FileGetContents([], $responseFactory ?: new MessageFactory());
-        if (!$requestFactory instanceof RequestFactoryInterface && !$requestFactory instanceof RequestFactory) {
+        if (null === $requestFactory) {
             $requestFactory = new MessageFactory();
+        }
+        if (!$requestFactory instanceof RequestFactoryInterface && !$requestFactory instanceof RequestFactory) {
+            throw new InvalidArgumentException('$requestFactory not a valid RequestFactory');
         }
         $this->requestFactory = $requestFactory;
     }

--- a/lib/Browser.php
+++ b/lib/Browser.php
@@ -11,6 +11,7 @@ use Buzz\Exception\InvalidArgumentException;
 use Buzz\Exception\LogicException;
 use Buzz\Middleware\MiddlewareInterface;
 use Http\Message\RequestFactory;
+use Http\Message\ResponseFactory;
 use Interop\Http\Factory\RequestFactoryInterface;
 use Interop\Http\Factory\ResponseFactoryInterface;
 use Nyholm\Psr7\Factory\MessageFactory;
@@ -39,17 +40,20 @@ class Browser implements BuzzClientInterface
     /**
      * Browser constructor.
      *
-     * @param BuzzClientInterface|null      $client
-     * @param RequestFactoryInterface|null  $requestFactory
-     * @param ResponseFactoryInterface|null $responseFactory To change the default response factory for FileGetContents
+     * @param BuzzClientInterface|null                      $client
+     * @param RequestFactoryInterface|RequestFactory|null   $requestFactory
+     * @param ResponseFactoryInterface|ResponseFactory|null $responseFactory To change the default response factory for FileGetContents
      */
     public function __construct(
         BuzzClientInterface $client = null,
-        ?RequestFactoryInterface $requestFactory = null,
-        ?ResponseFactoryInterface $responseFactory = null
+        $requestFactory = null,
+        $responseFactory = null
     ) {
         $this->client = $client ?: new FileGetContents([], $responseFactory ?: new MessageFactory());
-        $this->requestFactory = $requestFactory ?: new MessageFactory();
+        if (!$requestFactory instanceof RequestFactoryInterface && !$requestFactory instanceof RequestFactory) {
+            $requestFactory = new MessageFactory();
+        }
+        $this->requestFactory = $requestFactory;
     }
 
     public function get(string $url, array $headers = []): ResponseInterface

--- a/lib/Browser.php
+++ b/lib/Browser.php
@@ -38,9 +38,10 @@ class Browser implements BuzzClientInterface
 
     /**
      * Browser constructor.
-     * @param BuzzClientInterface|null $client
-     * @param RequestFactoryInterface|null $requestFactory
-     * @param ResponseFactoryInterface|null $responseFactory  To change the default response factory for FileGetContents
+     *
+     * @param BuzzClientInterface|null      $client
+     * @param RequestFactoryInterface|null  $requestFactory
+     * @param ResponseFactoryInterface|null $responseFactory To change the default response factory for FileGetContents
      */
     public function __construct(
         BuzzClientInterface $client = null,

--- a/lib/Browser.php
+++ b/lib/Browser.php
@@ -11,6 +11,7 @@ use Buzz\Exception\InvalidArgumentException;
 use Buzz\Exception\LogicException;
 use Buzz\Middleware\MiddlewareInterface;
 use Http\Message\RequestFactory;
+use \Http\Message\MessageFactory as MessageFactoryInterface;
 use Interop\Http\Factory\RequestFactoryInterface;
 use Nyholm\Psr7\Factory\MessageFactory;
 use Psr\Http\Message\RequestInterface;
@@ -35,10 +36,10 @@ class Browser implements BuzzClientInterface
     /** @var ResponseInterface */
     private $lastResponse;
 
-    public function __construct(BuzzClientInterface $client = null)
+    public function __construct(BuzzClientInterface $client = null, ?MessageFactoryInterface $factory = null)
     {
         $this->client = $client ?: new FileGetContents();
-        $this->factory = new MessageFactory();
+        $this->factory = $factory ?: new MessageFactory();
     }
 
     public function get(string $url, array $headers = []): ResponseInterface

--- a/lib/Browser.php
+++ b/lib/Browser.php
@@ -11,8 +11,8 @@ use Buzz\Exception\InvalidArgumentException;
 use Buzz\Exception\LogicException;
 use Buzz\Middleware\MiddlewareInterface;
 use Http\Message\RequestFactory;
-use Http\Message\MessageFactory as MessageFactoryInterface;
 use Interop\Http\Factory\RequestFactoryInterface;
+use Interop\Http\Factory\ResponseFactoryInterface;
 use Nyholm\Psr7\Factory\MessageFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -36,7 +36,7 @@ class Browser implements BuzzClientInterface
     /** @var ResponseInterface */
     private $lastResponse;
 
-    public function __construct(BuzzClientInterface $client = null, ?MessageFactoryInterface $factory = null)
+    public function __construct(BuzzClientInterface $client = null, ?ResponseFactoryInterface $factory = null)
     {
         $this->client = $client ?: new FileGetContents();
         $this->factory = $factory ?: new MessageFactory();

--- a/lib/Browser.php
+++ b/lib/Browser.php
@@ -23,7 +23,7 @@ class Browser implements BuzzClientInterface
     private $client;
 
     /** @var RequestFactoryInterface|RequestFactory */
-    private $factory;
+    private $requestFactory;
 
     /**
      * @var MiddlewareInterface[]
@@ -36,10 +36,19 @@ class Browser implements BuzzClientInterface
     /** @var ResponseInterface */
     private $lastResponse;
 
-    public function __construct(BuzzClientInterface $client = null, ?ResponseFactoryInterface $factory = null)
-    {
-        $this->client = $client ?: new FileGetContents();
-        $this->factory = $factory ?: new MessageFactory();
+    /**
+     * Browser constructor.
+     * @param BuzzClientInterface|null $client
+     * @param RequestFactoryInterface|null $requestFactory
+     * @param ResponseFactoryInterface|null $responseFactory  To change the default response factory for FileGetContents
+     */
+    public function __construct(
+        BuzzClientInterface $client = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?ResponseFactoryInterface $responseFactory = null
+    ) {
+        $this->client = $client ?: new FileGetContents([], $responseFactory ?: new MessageFactory());
+        $this->requestFactory = $requestFactory ?: new MessageFactory();
     }
 
     public function get(string $url, array $headers = []): ResponseInterface
@@ -252,7 +261,7 @@ class Browser implements BuzzClientInterface
 
     protected function createRequest(string $method, string $url, array $headers, $body): RequestInterface
     {
-        $request = $this->factory->createRequest($method, $url);
+        $request = $this->requestFactory->createRequest($method, $url);
         $request->getBody()->write($body);
         foreach ($headers as $name => $value) {
             $request = $request->withAddedHeader($name, $value);

--- a/lib/Client/AbstractClient.php
+++ b/lib/Client/AbstractClient.php
@@ -32,8 +32,11 @@ abstract class AbstractClient
     {
         $this->options = new ParameterBag();
         $this->options = $this->doValidateOptions($options);
-        if (!$responseFactory instanceof ResponseFactoryInterface && !$responseFactory instanceof ResponseFactory) {
+        if (null === $responseFactory) {
             $responseFactory = new MessageFactory();
+        }
+        if (!$responseFactory instanceof ResponseFactoryInterface && !$responseFactory instanceof ResponseFactory) {
+            throw new InvalidArgumentException('$responseFactory not a valid ResponseFactory');
         }
         $this->responseFactory = $responseFactory;
     }

--- a/lib/Client/AbstractClient.php
+++ b/lib/Client/AbstractClient.php
@@ -25,13 +25,13 @@ abstract class AbstractClient
     /**
      * @var ResponseFactoryInterface
      */
-    protected $messageFactory;
+    protected $responseFactory;
 
     public function __construct(array $options = [], ?ResponseFactoryInterface $messageFactory = null)
     {
         $this->options = new ParameterBag();
         $this->options = $this->doValidateOptions($options);
-        $this->messageFactory = $messageFactory ?: new MessageFactory();
+        $this->responseFactory = $messageFactory ?: new MessageFactory();
     }
 
     protected function getOptionsResolver(): OptionsResolver

--- a/lib/Client/AbstractClient.php
+++ b/lib/Client/AbstractClient.php
@@ -6,6 +6,8 @@ namespace Buzz\Client;
 
 use Buzz\Configuration\ParameterBag;
 use Buzz\Exception\InvalidArgumentException;
+use Http\Message\MessageFactory as MessageFactoryInterface;
+use Nyholm\Psr7\Factory\MessageFactory;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 abstract class AbstractClient
@@ -20,10 +22,16 @@ abstract class AbstractClient
      */
     private $options;
 
-    public function __construct(array $options = [])
+    /**
+     * @var MessageFactoryInterface
+     */
+    protected $messageFactory;
+
+    public function __construct(array $options = [], ?MessageFactoryInterface $messageFactory = null)
     {
         $this->options = new ParameterBag();
         $this->options = $this->doValidateOptions($options);
+        $this->messageFactory = $messageFactory ?: new MessageFactory();
     }
 
     protected function getOptionsResolver(): OptionsResolver

--- a/lib/Client/AbstractClient.php
+++ b/lib/Client/AbstractClient.php
@@ -6,6 +6,7 @@ namespace Buzz\Client;
 
 use Buzz\Configuration\ParameterBag;
 use Buzz\Exception\InvalidArgumentException;
+use Http\Message\ResponseFactory;
 use Interop\Http\Factory\ResponseFactoryInterface;
 use Nyholm\Psr7\Factory\MessageFactory;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -23,15 +24,18 @@ abstract class AbstractClient
     private $options;
 
     /**
-     * @var ResponseFactoryInterface
+     * @var ResponseFactoryInterface|ResponseFactory
      */
     protected $responseFactory;
 
-    public function __construct(array $options = [], ?ResponseFactoryInterface $messageFactory = null)
+    public function __construct(array $options = [], $responseFactory = null)
     {
         $this->options = new ParameterBag();
         $this->options = $this->doValidateOptions($options);
-        $this->responseFactory = $messageFactory ?: new MessageFactory();
+        if (!$responseFactory instanceof ResponseFactoryInterface && !$responseFactory instanceof ResponseFactory) {
+            $responseFactory = new MessageFactory();
+        }
+        $this->responseFactory = $responseFactory;
     }
 
     protected function getOptionsResolver(): OptionsResolver

--- a/lib/Client/AbstractClient.php
+++ b/lib/Client/AbstractClient.php
@@ -6,7 +6,7 @@ namespace Buzz\Client;
 
 use Buzz\Configuration\ParameterBag;
 use Buzz\Exception\InvalidArgumentException;
-use Http\Message\MessageFactory as MessageFactoryInterface;
+use Interop\Http\Factory\ResponseFactoryInterface;
 use Nyholm\Psr7\Factory\MessageFactory;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -23,11 +23,11 @@ abstract class AbstractClient
     private $options;
 
     /**
-     * @var MessageFactoryInterface
+     * @var ResponseFactoryInterface
      */
     protected $messageFactory;
 
-    public function __construct(array $options = [], ?MessageFactoryInterface $messageFactory = null)
+    public function __construct(array $options = [], ?ResponseFactoryInterface $messageFactory = null)
     {
         $this->options = new ParameterBag();
         $this->options = $this->doValidateOptions($options);

--- a/lib/Client/AbstractCurl.php
+++ b/lib/Client/AbstractCurl.php
@@ -10,7 +10,6 @@ use Buzz\Exception\ClientException;
 use Buzz\Exception\NetworkException;
 use Buzz\Exception\RequestException;
 use Buzz\Message\ResponseBuilder;
-use Nyholm\Psr7\Factory\MessageFactory;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 

--- a/lib/Client/AbstractCurl.php
+++ b/lib/Client/AbstractCurl.php
@@ -94,7 +94,7 @@ abstract class AbstractCurl extends AbstractClient
         $this->setOptionsFromParameterBag($curl, $options);
         $this->setOptionsFromRequest($curl, $request);
 
-        $responseBuilder = new ResponseBuilder(new MessageFactory());
+        $responseBuilder = new ResponseBuilder($this->messageFactory);
         curl_setopt($curl, CURLOPT_HEADERFUNCTION, function ($ch, $data) use ($responseBuilder) {
             $str = trim($data);
             if ('' !== $str) {

--- a/lib/Client/AbstractCurl.php
+++ b/lib/Client/AbstractCurl.php
@@ -93,7 +93,7 @@ abstract class AbstractCurl extends AbstractClient
         $this->setOptionsFromParameterBag($curl, $options);
         $this->setOptionsFromRequest($curl, $request);
 
-        $responseBuilder = new ResponseBuilder($this->messageFactory);
+        $responseBuilder = new ResponseBuilder($this->responseFactory);
         curl_setopt($curl, CURLOPT_HEADERFUNCTION, function ($ch, $data) use ($responseBuilder) {
             $str = trim($data);
             if ('' !== $str) {

--- a/lib/Client/FileGetContents.php
+++ b/lib/Client/FileGetContents.php
@@ -8,7 +8,6 @@ use Buzz\Configuration\ParameterBag;
 use Buzz\Message\HeaderConverter;
 use Buzz\Exception\NetworkException;
 use Buzz\Message\ResponseBuilder;
-use Nyholm\Psr7\Factory\MessageFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -28,7 +27,7 @@ class FileGetContents extends AbstractClient implements BuzzClientInterface
             throw new NetworkException($request, $error['message']);
         }
 
-        $requestBuilder = new ResponseBuilder(new MessageFactory());
+        $requestBuilder = new ResponseBuilder($this->messageFactory);
         $requestBuilder->parseHttpHeaders($this->filterHeaders((array) $http_response_header));
         $requestBuilder->writeBody($content);
 

--- a/lib/Client/FileGetContents.php
+++ b/lib/Client/FileGetContents.php
@@ -27,7 +27,7 @@ class FileGetContents extends AbstractClient implements BuzzClientInterface
             throw new NetworkException($request, $error['message']);
         }
 
-        $requestBuilder = new ResponseBuilder($this->messageFactory);
+        $requestBuilder = new ResponseBuilder($this->responseFactory);
         $requestBuilder->parseHttpHeaders($this->filterHeaders((array) $http_response_header));
         $requestBuilder->writeBody($content);
 


### PR DESCRIPTION
Remove the hard coded dependency on `nyholm/psr7` but still use it as default implementation.

What i saw it didn't break any tests