### PR TITLE
Add colon between hostname and port when converting PSR7 to Buzz request

### DIFF
--- a/lib/Buzz/Converter/RequestConverter.php
+++ b/lib/Buzz/Converter/RequestConverter.php
@@ -56,7 +56,7 @@ class RequestConverter
         $buzzRequest = new Request(
             $request->getMethod(),
             sprintf('%s?%s', $uri->getPath(), $uri->getQuery()),
-            $uri->getScheme().'://'.$uri->getHost().($uri->getPort() !== null ? $uri->getPort() : '')
+            $uri->getScheme().'://'.$uri->getHost().($uri->getPort() !== null ? ':'.$uri->getPort() : '')
         );
 
         $buzzRequest->addHeaders(HeaderConverter::toBuzzHeaders($request->getHeaders()));

--- a/test/Buzz/Test/Converter/RequestConverterTest.php
+++ b/test/Buzz/Test/Converter/RequestConverterTest.php
@@ -10,23 +10,23 @@ class RequestConverterTest extends TestCase
 {
     public function testPsr7()
     {
-        $buzz = new Request(Request::METHOD_GET, '/foo', 'https://example.com');
+        $buzz = new Request(Request::METHOD_GET, '/foo', 'https://example.com:80');
         $buzz->setContent('Foobar');
 
         $psr = RequestConverter::psr7($buzz);
         $this->assertEquals('GET', $psr->getMethod());
         $this->assertEquals('/foo', $psr->getUri()->getPath());
-        $this->assertEquals('https://example.com/foo', $psr->getUri()->__toString());
+        $this->assertEquals('https://example.com:80/foo', $psr->getUri()->__toString());
         $this->assertEquals('Foobar', $psr->getBody()->__toString());
     }
     public function testBuzz()
     {
-        $psr = new \GuzzleHttp\Psr7\Request('GET', 'https://example.com/foo?bar', ['header'=>'value'], 'Foobar');
+        $psr = new \GuzzleHttp\Psr7\Request('GET', 'https://example.com:80/foo?bar', ['header'=>'value'], 'Foobar');
 
         $buzz = RequestConverter::buzz($psr);
         $this->assertEquals('GET', $buzz->getMethod());
         $this->assertEquals('/foo?bar', $buzz->getResource());
-        $this->assertEquals('https://example.com', $buzz->getHost());
+        $this->assertEquals('https://example.com:80', $buzz->getHost());
         $this->assertEquals('Foobar', $buzz->getContent());
     }
 }

--- a/test/Buzz/Test/Converter/RequestConverterTest.php
+++ b/test/Buzz/Test/Converter/RequestConverterTest.php
@@ -10,23 +10,37 @@ class RequestConverterTest extends TestCase
 {
     public function testPsr7()
     {
-        $buzz = new Request(Request::METHOD_GET, '/foo', 'https://example.com:80');
+        $buzz = new Request(Request::METHOD_GET, '/foo', 'https://example.com');
         $buzz->setContent('Foobar');
 
         $psr = RequestConverter::psr7($buzz);
         $this->assertEquals('GET', $psr->getMethod());
         $this->assertEquals('/foo', $psr->getUri()->getPath());
-        $this->assertEquals('https://example.com:80/foo', $psr->getUri()->__toString());
+        $this->assertEquals('https://example.com/foo', $psr->getUri()->__toString());
         $this->assertEquals('Foobar', $psr->getBody()->__toString());
+    }
+    public function testPsr7Port()
+    {
+        $buzz = new Request(Request::METHOD_GET, '/foo', 'https://example.com:8080');
+
+        $psr = RequestConverter::psr7($buzz);
+        $this->assertEquals('https://example.com:8080/foo', $psr->getUri()->__toString());
     }
     public function testBuzz()
     {
-        $psr = new \GuzzleHttp\Psr7\Request('GET', 'https://example.com:80/foo?bar', ['header'=>'value'], 'Foobar');
+        $psr = new \GuzzleHttp\Psr7\Request('GET', 'https://example.com/foo?bar', ['header'=>'value'], 'Foobar');
 
         $buzz = RequestConverter::buzz($psr);
         $this->assertEquals('GET', $buzz->getMethod());
         $this->assertEquals('/foo?bar', $buzz->getResource());
-        $this->assertEquals('https://example.com:80', $buzz->getHost());
+        $this->assertEquals('https://example.com', $buzz->getHost());
         $this->assertEquals('Foobar', $buzz->getContent());
+    }
+    public function testBuzzPort()
+    {
+        $psr = new \GuzzleHttp\Psr7\Request('GET', 'https://example.com:8080/foo?bar');
+
+        $buzz = RequestConverter::buzz($psr);
+        $this->assertEquals('https://example.com:8080', $buzz->getHost());
     }
 }

--- a/test/Buzz/Test/Converter/ResponseConverterTest.php
+++ b/test/Buzz/Test/Converter/ResponseConverterTest.php
@@ -2,9 +2,7 @@
 
 namespace Buzz\Test\Converter;
 
-use Buzz\Converter\RequestConverter;
 use Buzz\Converter\ResponseConverter;
-use Buzz\Message\Request;
 use Buzz\Message\Response;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
When converting from PSR7 Request to Buzz Request using the RequestConverter, the colon between the hostname and port number is missing. This PR fixes that.