### PR TITLE
Mark Browser::addListener() as deprecated

### DIFF
--- a/lib/Buzz/Browser.php
+++ b/lib/Buzz/Browser.php
@@ -329,6 +329,11 @@ class Browser
         $this->middlewares[] = $middleware;
     }
 
+    /**
+     * @deprecated Use addMiddleware instead.
+     *
+     * @param ListenerInterface $listener
+     */
     public function addListener(ListenerInterface $listener)
     {
         if (!$this->listener) {


### PR DESCRIPTION
* listeners are no longer used