### PR TITLE
Implement Content-Type middleware

### DIFF
--- a/lib/Middleware/ContentTypeMiddleware.php
+++ b/lib/Middleware/ContentTypeMiddleware.php
@@ -54,23 +54,15 @@ class ContentTypeMiddleware implements MiddlewareInterface
      */
     public function handleRequest(RequestInterface $request, callable $next)
     {
-        if ($this->skipDetection) {
-            return $next($request);
-        }
-
-       if ($request->hasHeader('Content-Type')) {
+        if ($this->skipDetection && $request->hasHeader('Content-Type')) {
             return $next($request);
         }
 
         $stream = $request->getBody();
         $streamSize = $stream->getSize();
 
-        if (null === $streamSize || $streamSize >= $this->sizeLimit || 0 === $streamSize) 
+        if (empty($streamSize) || $streamSize >= $this->sizeLimit || !$stream->isSeekable()) 
         {
-            return $next($request);
-        }
-
-        if(!$stream->isSeekable()) {
             return $next($request);
         }
 

--- a/lib/Middleware/ContentTypeMiddleware.php
+++ b/lib/Middleware/ContentTypeMiddleware.php
@@ -61,16 +61,17 @@ class ContentTypeMiddleware implements MiddlewareInterface
         $stream = $request->getBody();
         $streamSize = $stream->getSize();
 
-        if (empty($streamSize) || $streamSize >= $this->sizeLimit || !$stream->isSeekable()) 
-        {
+        if (empty($streamSize) || $streamSize >= $this->sizeLimit || !$stream->isSeekable()) {
             return $next($request);
         }
 
         if ($this->isJson($stream)) {
             $request = $request->withHeader('Content-Type', 'application/json');
+
             return $next($request);
-        } elseif($this->isXml($stream)) {
+        } elseif ($this->isXml($stream)) {
             $request = $request->withHeader('Content-Type', 'application/xml');
+
             return $next($request);
         }
     }
@@ -92,8 +93,10 @@ class ContentTypeMiddleware implements MiddlewareInterface
     {
         $stream->rewind();
         json_decode($stream->getContents());
+
         return JSON_ERROR_NONE === json_last_error();
     }
+
     /**
      * @param $stream StreamInterface
      *
@@ -105,6 +108,7 @@ class ContentTypeMiddleware implements MiddlewareInterface
         $previousValue = libxml_use_internal_errors(true);
         $isXml = simplexml_load_string($stream->getContents());
         libxml_use_internal_errors($previousValue);
+
         return $isXml;
     }
 }

--- a/lib/Middleware/ContentTypeMiddleware.php
+++ b/lib/Middleware/ContentTypeMiddleware.php
@@ -54,7 +54,7 @@ class ContentTypeMiddleware implements MiddlewareInterface
      */
     public function handleRequest(RequestInterface $request, callable $next)
     {
-        if ($this->skipDetection && $request->hasHeader('Content-Type')) {
+        if ($this->skipDetection || $request->hasHeader('Content-Type')) {
             return $next($request);
         }
 

--- a/lib/Middleware/ContentTypeMiddleware.php
+++ b/lib/Middleware/ContentTypeMiddleware.php
@@ -54,34 +54,33 @@ class ContentTypeMiddleware implements MiddlewareInterface
      */
     public function handleRequest(RequestInterface $request, callable $next)
     {
-       if (!$request->hasHeader('Content-Type')) {
-            $stream = $request->getBody();
-            $streamSize = $stream->getSize();
-
-            if (!$stream->isSeekable()) {
-                return $next($request);
-            }
-
-            if (0 === $streamSize) {
-                return $next($request);
-            }
-
-            if ($this->skipDetection && (null === $streamSize || $streamSize >= $this->sizeLimit)) {
-                return $next($request);
-            }
-
-            if ($this->isJson($stream)) {
-                $request = $request->withHeader('Content-Type', 'application/json');
-                return $next($request);
-            }
-
-            if ($this->isXml($stream)) {
-                $request = $request->withHeader('Content-Type', 'application/xml');
-                return $next($request);
-            }
+        if ($this->skipDetection) {
+            return $next($request);
         }
 
-        return $next($request);
+       if ($request->hasHeader('Content-Type')) {
+            return $next($request);
+        }
+
+        $stream = $request->getBody();
+        $streamSize = $stream->getSize();
+
+        if (null === $streamSize || $streamSize >= $this->sizeLimit || 0 === $streamSize) 
+        {
+            return $next($request);
+        }
+
+        if(!$stream->isSeekable()) {
+            return $next($request);
+        }
+
+        if ($this->isJson($stream)) {
+            $request = $request->withHeader('Content-Type', 'application/json');
+            return $next($request);
+        } elseif($this->isXml($stream)) {
+            $request = $request->withHeader('Content-Type', 'application/xml');
+            return $next($request);
+        }
     }
 
     /**

--- a/lib/Middleware/ContentTypeMiddleware.php
+++ b/lib/Middleware/ContentTypeMiddleware.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buzz\Middleware;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ContentTypeMiddleware implements MiddlewareInterface
+{
+    /**
+     * Allow to disable the content type detection when stream is too large (as it can consume a lot of resource).
+     *
+     * @var bool
+     *
+     * true     skip the content type detection
+     * false    detect the content type (default value)
+     */
+    protected $skipDetection;
+
+    /**
+     * Determine the size stream limit for which the detection as to be skipped (default to 16Mb).
+     *
+     * @var int
+     */
+    protected $sizeLimit;
+
+    /**
+     * @param array $config {
+     *
+     *     @var bool $skip_detection True skip detection if stream size is bigger than $size_limit.
+     *     @var int $size_limit size stream limit for which the detection as to be skipped.
+     * }
+     */
+    public function __construct(array $config = [])
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'skip_detection' => false,
+            'size_limit' => 16000000,
+        ]);
+        $resolver->setAllowedTypes('skip_detection', 'bool');
+        $resolver->setAllowedTypes('size_limit', 'int');
+        $options = $resolver->resolve($config);
+        $this->skipDetection = $options['skip_detection'];
+        $this->sizeLimit = $options['size_limit'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleRequest(RequestInterface $request, callable $next)
+    {
+       if (!$request->hasHeader('Content-Type')) {
+            $stream = $request->getBody();
+            $streamSize = $stream->getSize();
+
+            if (!$stream->isSeekable()) {
+                return $next($request);
+            }
+
+            if (0 === $streamSize) {
+                return $next($request);
+            }
+
+            if ($this->skipDetection && (null === $streamSize || $streamSize >= $this->sizeLimit)) {
+                return $next($request);
+            }
+
+            if ($this->isJson($stream)) {
+                $request = $request->withHeader('Content-Type', 'application/json');
+                return $next($request);
+            }
+
+            if ($this->isXml($stream)) {
+                $request = $request->withHeader('Content-Type', 'application/xml');
+                return $next($request);
+            }
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleResponse(RequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        return $next($request, $response);
+    }
+
+    /**
+     * @param $stream StreamInterface
+     *
+     * @return bool
+     */
+    private function isJson($stream)
+    {
+        $stream->rewind();
+        json_decode($stream->getContents());
+        return JSON_ERROR_NONE === json_last_error();
+    }
+    /**
+     * @param $stream StreamInterface
+     *
+     * @return \SimpleXMLElement|false
+     */
+    private function isXml($stream)
+    {
+        $stream->rewind();
+        $previousValue = libxml_use_internal_errors(true);
+        $isXml = simplexml_load_string($stream->getContents());
+        libxml_use_internal_errors($previousValue);
+        return $isXml;
+    }
+}

--- a/lib/Middleware/ContentTypeMiddleware.php
+++ b/lib/Middleware/ContentTypeMiddleware.php
@@ -31,7 +31,7 @@ class ContentTypeMiddleware implements MiddlewareInterface
     /**
      * @param array $config {
      *
-     *     @var bool $skip_detection True skip detection if stream size is bigger than $size_limit.
+     *     @var bool $skip_detection True skip detection if stream size is bigger than $size_limit
      *     @var int $size_limit size stream limit for which the detection as to be skipped.
      * }
      */

--- a/tests/Unit/Middleware/ContentTypeMiddlewareTest.php
+++ b/tests/Unit/Middleware/ContentTypeMiddlewareTest.php
@@ -12,12 +12,11 @@ use Psr\Http\Message\RequestInterface;
 class ContentTypeMiddlewareTest extends TestCase
 {
     public function testMiddleware()
-    {   
-
+    {
         // XML
-        $request = new Request('GET', 
-                                'http://foo.com', 
-                                [], 
+        $request = new Request('GET',
+                                'http://foo.com',
+                                [],
                                 '<?xml version="1.0" encoding="UTF-8"?>
                                 <note>
                                   <to>Lorem</to>
@@ -36,8 +35,8 @@ class ContentTypeMiddlewareTest extends TestCase
         $this->assertEquals('application/xml', $updatedRequest->getHeaderLine('Content-Type'));
 
         //JSON
-        $request = new Request('GET', 
-                                'http://foo.com', 
+        $request = new Request('GET',
+                                'http://foo.com',
                                 [],
                                 '{
                                   "userId": 1,
@@ -54,7 +53,5 @@ class ContentTypeMiddlewareTest extends TestCase
         });
 
         $this->assertEquals('application/json', $updatedRequest->getHeaderLine('Content-Type'));
-
-        
     }
 }

--- a/tests/Unit/Middleware/ContentTypeMiddlewareTest.php
+++ b/tests/Unit/Middleware/ContentTypeMiddlewareTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buzz\Test\Unit\Middleware;
+
+use Buzz\Middleware\ContentTypeMiddleware;
+use Nyholm\Psr7\Request;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class ContentTypeMiddlewareTest extends TestCase
+{
+    public function testMiddleware()
+    {   
+
+        // XML
+        $request = new Request('GET', 
+                                'http://foo.com', 
+                                [], 
+                                '<?xml version="1.0" encoding="UTF-8"?>
+                                <note>
+                                  <to>Lorem</to>
+                                  <from>Ipsum</from>
+                                  <heading>Lorem</heading>
+                                  <body>Ipsum</body>
+                                </note>');
+
+        /** @var RequestInterface $updatedRequest */
+        $updatedRequest = null;
+        $middleware = new ContentTypeMiddleware();
+        $middleware->handleRequest($request, function (RequestInterface $request) use (&$updatedRequest) {
+            $updatedRequest = $request;
+        });
+
+        $this->assertEquals('application/xml', $updatedRequest->getHeaderLine('Content-Type'));
+
+        //JSON
+        $request = new Request('GET', 
+                                'http://foo.com', 
+                                [],
+                                '{
+                                  "userId": 1,
+                                  "id": 1,
+                                  "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
+                                  "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
+                                }');
+
+        /** @var RequestInterface $updatedRequest */
+        $updatedRequest = null;
+        $middleware = new ContentTypeMiddleware();
+        $middleware->handleRequest($request, function (RequestInterface $request) use (&$updatedRequest) {
+            $updatedRequest = $request;
+        });
+
+        $this->assertEquals('application/json', $updatedRequest->getHeaderLine('Content-Type'));
+
+        
+    }
+}


### PR DESCRIPTION
Added Content-Type middleware. Code ported from HTTPlug's CT plugin, as so, currently supports JSON and XML.