### PR TITLE
Add ca_file option to clients

### DIFF
--- a/lib/Client/AbstractClient.php
+++ b/lib/Client/AbstractClient.php
@@ -90,6 +90,7 @@ abstract class AbstractClient
             'timeout' => 30,
             'verify' => true,
             'proxy' => null,
+            'ca_file' => null,
         ]);
 
         $resolver->setAllowedTypes('allow_redirects', 'boolean');
@@ -97,5 +98,6 @@ abstract class AbstractClient
         $resolver->setAllowedTypes('max_redirects', 'integer');
         $resolver->setAllowedTypes('timeout', ['integer', 'float']);
         $resolver->setAllowedTypes('proxy', ['null', 'string']);
+        $resolver->setAllowedTypes('ca_file', ['null', 'string']);
     }
 }

--- a/lib/Client/AbstractCurl.php
+++ b/lib/Client/AbstractCurl.php
@@ -195,6 +195,11 @@ abstract class AbstractCurl extends AbstractClient
             curl_setopt($curl, CURLOPT_PROXY, $proxy);
         }
 
+        $caFile = $options->get('ca_file');
+        if (null !== $caFile) {
+            curl_setopt($curl, CURLOPT_CAINFO, $caFile);
+        }
+
         $canFollow = !ini_get('safe_mode') && !ini_get('open_basedir') && $options->get('allow_redirects');
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, $canFollow);
         curl_setopt($curl, CURLOPT_MAXREDIRS, $canFollow ? $options->get('max_redirects') : 0);

--- a/lib/Client/FileGetContents.php
+++ b/lib/Client/FileGetContents.php
@@ -71,6 +71,11 @@ class FileGetContents extends AbstractClient implements BuzzClientInterface
             $context['http']['request_fulluri'] = true;
         }
 
+        $caFile = $options->get('ca_file');
+        if (null !== $caFile) {
+            $context['ssl']['cafile'] = $caFile;
+        }
+
         return $context;
     }
 

--- a/lib/Client/FileGetContents.php
+++ b/lib/Client/FileGetContents.php
@@ -62,7 +62,6 @@ class FileGetContents extends AbstractClient implements BuzzClientInterface
             ],
             'ssl' => [
                 'verify_peer' => $options->get('verify'),
-                'verify_host' => $options->get('verify'),
             ],
         ];
 

--- a/tests/Unit/Client/FileGetContentsTest.php
+++ b/tests/Unit/Client/FileGetContentsTest.php
@@ -43,6 +43,7 @@ class FileGetContentsTest extends TestCase
             'ssl' => [
                 'verify_peer' => true,
                 'verify_host' => 2,
+                'cafile' => '/file/path.crt',
             ],
         ];
 
@@ -51,6 +52,7 @@ class FileGetContentsTest extends TestCase
             'timeout' => 10,
             'allow_redirects' => true,
             'verify' => true,
+            'ca_file' => '/file/path.crt',
         ]);
         $this->assertEquals($expected, $client->getStreamContextArray($request, $options));
 

--- a/tests/Unit/Client/FileGetContentsTest.php
+++ b/tests/Unit/Client/FileGetContentsTest.php
@@ -42,7 +42,6 @@ class FileGetContentsTest extends TestCase
             ],
             'ssl' => [
                 'verify_peer' => true,
-                'verify_host' => 2,
                 'cafile' => '/file/path.crt',
             ],
         ];
@@ -58,7 +57,6 @@ class FileGetContentsTest extends TestCase
 
         $options = $options->add(['verify' => false]);
         $expected['ssl']['verify_peer'] = false;
-        $expected['ssl']['verify_host'] = false;
         $this->assertEquals($expected, $client->getStreamContextArray($request, $options));
 
         $options = $options->add(['max_redirects' => 0]);


### PR DESCRIPTION
refers to https://github.com/kriswallsmith/Buzz/issues/347

---

Second commit removes `verify_host` in FileGetContents client. The option is not documented or invalid ( http://php.net/manual/en/context.ssl.php )