### PR TITLE
Add self signed certificate support

### DIFF
--- a/lib/Client/FileGetContents.php
+++ b/lib/Client/FileGetContents.php
@@ -63,6 +63,8 @@ class FileGetContents extends AbstractClient implements BuzzClientInterface
             'ssl' => [
                 'verify_peer' => $options->get('verify'),
                 'verify_host' => $options->get('verify'),
+                'verify_peer_name' => $options->get('verify'),
+                'allow_self_signed' => $options->get('verify') ? false : true
             ],
         ];
 

--- a/lib/Client/FileGetContents.php
+++ b/lib/Client/FileGetContents.php
@@ -64,7 +64,7 @@ class FileGetContents extends AbstractClient implements BuzzClientInterface
                 'verify_peer' => $options->get('verify'),
                 'verify_host' => $options->get('verify'),
                 'verify_peer_name' => $options->get('verify'),
-                'allow_self_signed' => $options->get('verify') ? false : true
+                'allow_self_signed' => $options->get('verify') ? false : true,
             ],
         ];
 

--- a/tests/Unit/Client/FileGetContentsTest.php
+++ b/tests/Unit/Client/FileGetContentsTest.php
@@ -41,6 +41,8 @@ class FileGetContentsTest extends TestCase
             'ssl' => [
                 'verify_peer' => true,
                 'verify_host' => 2,
+                'verify_peer_name' => true,
+                'allow_self_signed' => false,
             ],
         ];
 
@@ -55,6 +57,8 @@ class FileGetContentsTest extends TestCase
         $options = $options->add(['verify' => false]);
         $expected['ssl']['verify_peer'] = false;
         $expected['ssl']['verify_host'] = false;
+        $expected['ssl']['verify_peer_name'] = false;
+        $expected['ssl']['allow_self_signed'] = true;
         $this->assertEquals($expected, $client->getStreamContextArray($request, $options));
 
         $options = $options->add(['max_redirects' => 0]);


### PR DESCRIPTION
If verify is false, then it should be possible to make requests to endpoints having self-signed SSL certificates and/ or endpoints having SSL that do not support the current domain.
We need this e.g. for making requests from a docker container to another docker container in local dev environment using `host.docker.internal` as domain