### PR TITLE
Make timeout "null" by default.

### DIFF
--- a/doc/client.md
+++ b/doc/client.md
@@ -117,7 +117,7 @@ $options['push_function_callback'] = function ($parent, $pushed, $headers) {
 #### timeout
 
 Type: integer<br>
-Default: `null`
+Default: `0`
 
 The time to wait before interrupt the request.
 

--- a/doc/client.md
+++ b/doc/client.md
@@ -117,7 +117,7 @@ $options['push_function_callback'] = function ($parent, $pushed, $headers) {
 #### timeout
 
 Type: integer<br>
-Default: `0`
+Default: `0` (no limit)
 
 The time to wait before interrupt the request.
 

--- a/doc/client.md
+++ b/doc/client.md
@@ -117,7 +117,7 @@ $options['push_function_callback'] = function ($parent, $pushed, $headers) {
 #### timeout
 
 Type: integer<br>
-Default: `30` (`null` on MultiCurl)
+Default: `null`
 
 The time to wait before interrupt the request.
 

--- a/lib/Client/AbstractClient.php
+++ b/lib/Client/AbstractClient.php
@@ -87,7 +87,7 @@ abstract class AbstractClient
         $resolver->setDefaults([
             'allow_redirects' => false,
             'max_redirects' => 5,
-            'timeout' => 30,
+            'timeout' => null,
             'verify' => true,
             'proxy' => null,
         ]);
@@ -95,7 +95,7 @@ abstract class AbstractClient
         $resolver->setAllowedTypes('allow_redirects', 'boolean');
         $resolver->setAllowedTypes('verify', 'boolean');
         $resolver->setAllowedTypes('max_redirects', 'integer');
-        $resolver->setAllowedTypes('timeout', ['integer', 'float']);
+        $resolver->setAllowedTypes('timeout', ['integer', 'float', 'null']);
         $resolver->setAllowedTypes('proxy', ['null', 'string']);
     }
 }

--- a/lib/Client/AbstractClient.php
+++ b/lib/Client/AbstractClient.php
@@ -87,7 +87,7 @@ abstract class AbstractClient
         $resolver->setDefaults([
             'allow_redirects' => false,
             'max_redirects' => 5,
-            'timeout' => null,
+            'timeout' => 0,
             'verify' => true,
             'proxy' => null,
         ]);
@@ -95,7 +95,7 @@ abstract class AbstractClient
         $resolver->setAllowedTypes('allow_redirects', 'boolean');
         $resolver->setAllowedTypes('verify', 'boolean');
         $resolver->setAllowedTypes('max_redirects', 'integer');
-        $resolver->setAllowedTypes('timeout', ['integer', 'float', 'null']);
+        $resolver->setAllowedTypes('timeout', ['integer', 'float']);
         $resolver->setAllowedTypes('proxy', ['null', 'string']);
     }
 }

--- a/lib/Client/AbstractCurl.php
+++ b/lib/Client/AbstractCurl.php
@@ -198,7 +198,9 @@ abstract class AbstractCurl extends AbstractClient
         curl_setopt($curl, CURLOPT_MAXREDIRS, $canFollow ? $options->get('max_redirects') : 0);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $options->get('verify') ? 1 : 0);
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, $options->get('verify') ? 2 : 0);
-        curl_setopt($curl, CURLOPT_TIMEOUT, $options->get('timeout'));
+        if (0 < $options->get('timeout')) {
+            curl_setopt($curl, CURLOPT_TIMEOUT, $options->get('timeout'));
+        }
     }
 
     /**

--- a/lib/Client/FileGetContents.php
+++ b/lib/Client/FileGetContents.php
@@ -57,13 +57,16 @@ class FileGetContents extends AbstractClient implements BuzzClientInterface
                 'ignore_errors' => true,
                 'follow_location' => $options->get('allow_redirects') && $options->get('max_redirects') > 0,
                 'max_redirects' => $options->get('max_redirects') + 1,
-                'timeout' => $options->get('timeout'),
             ],
             'ssl' => [
                 'verify_peer' => $options->get('verify'),
                 'verify_host' => $options->get('verify'),
             ],
         ];
+
+        if (0 < $options->get('timeout')) {
+            $context['http']['timeout'] = $options->get('timeout');
+        }
 
         if (null !== $options->get('proxy')) {
             $context['http']['proxy'] = $options->get('proxy');

--- a/lib/Client/MultiCurl.php
+++ b/lib/Client/MultiCurl.php
@@ -126,11 +126,6 @@ class MultiCurl extends AbstractCurl implements BatchClientInterface, BuzzClient
 
         $resolver->setDefault('use_pushed_response', true);
         $resolver->setAllowedTypes('use_pushed_response', 'boolean');
-
-        // There is a bug in PHP that disables the server push feature if you are using timeouts.
-        // See https://bugs.php.net/bug.php?id=77497
-        $resolver->setDefault('timeout', null);
-        $resolver->setAllowedTypes('timeout', ['integer', 'float', 'null']);
     }
 
     public function count(): int


### PR DESCRIPTION
This is to make sure all our clients acts the same and to be the same as guzzle