### PR TITLE
Fix docs: change client send method name to sendRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ use Buzz\Client\FileGetContents;
 $request = new PSR7Request('GET', 'https://google.com/foo');
 
 $client = new FileGetContents(new Psr17ResponseFactory());
-$response = $client->send($request, ['timeout' => 4]);
+$response = $client->sendRequest($request, ['timeout' => 4]);
 
 echo $response->getStatusCode();
 ```

--- a/doc/client.md
+++ b/doc/client.md
@@ -16,7 +16,7 @@ use Nyholm\Psr7\Request;
 $request = new Request('GET', 'https://example.com');
 
 $client = new FileGetContents(new Psr17Factory(), ['allow_redirects' => true]);
-$response = $client->send($request, ['timeout' => 4]);
+$response = $client->sendRequest($request, ['timeout' => 4]);
 ```
 
 ## Configuration


### PR DESCRIPTION
Correct method name is `sendRequest()` instead of just `send()`.