### PR TITLE
Fixed ContentTypeMiddleware Return null

### DIFF
--- a/lib/Middleware/ContentTypeMiddleware.php
+++ b/lib/Middleware/ContentTypeMiddleware.php
@@ -74,7 +74,7 @@ class ContentTypeMiddleware implements MiddlewareInterface
 
             return $next($request);
         }
-        
+
         return $next($request);
     }
 

--- a/lib/Middleware/ContentTypeMiddleware.php
+++ b/lib/Middleware/ContentTypeMiddleware.php
@@ -74,6 +74,8 @@ class ContentTypeMiddleware implements MiddlewareInterface
 
             return $next($request);
         }
+        
+        return $next($request);
     }
 
     /**


### PR DESCRIPTION
```php
        $client = new Curl(new Psr17Factory());
        $browser = new Browser($client, new Psr17Factory());
        $browser->addMiddleware(new ContentTypeMiddleware());


        $response = $browser->post('https://httpbin.org/post', [], 'test=body');
        echo $response->getBody()->__toString();
```
reproduce code