### PR TITLE
NullException when creating NetworkException

### DIFF
--- a/lib/Client/FileGetContents.php
+++ b/lib/Client/FileGetContents.php
@@ -17,10 +17,13 @@ class FileGetContents extends AbstractClient implements BuzzClientInterface
     {
         $options = $this->validateOptions($options);
         $context = stream_context_create($this->getStreamContextArray($request, $options));
+
+        $level = error_reporting(0);
         $content = file_get_contents($request->getUri()->__toString(), false, $context);
+        error_reporting($level);
         if (false === $content) {
-            if (($error = error_get_last())) {
-              throw new NetworkException($request, $error['message']);
+            if ($error = error_get_last()) {
+                throw new NetworkException($request, $error['message']);
             }
             throw new NetworkException($request, 'Failed to get contents from '.$request->getUri()->__toString());
         }

--- a/lib/Client/FileGetContents.php
+++ b/lib/Client/FileGetContents.php
@@ -17,14 +17,12 @@ class FileGetContents extends AbstractClient implements BuzzClientInterface
     {
         $options = $this->validateOptions($options);
         $context = stream_context_create($this->getStreamContextArray($request, $options));
-
-        $level = error_reporting(0);
         $content = file_get_contents($request->getUri()->__toString(), false, $context);
-        error_reporting($level);
         if (false === $content) {
-            $error = error_get_last();
-
-            throw new NetworkException($request, $error['message']);
+            if (($error = error_get_last())) {
+              throw new NetworkException($request, $error['message']);
+            }
+            throw new NetworkException($request, 'Failed to get contents from '.$request->getUri()->__toString());
         }
 
         $requestBuilder = new ResponseBuilder($this->responseFactory);


### PR DESCRIPTION
In some case of file_get_contents error, there is no error message (null) so  the new NetworkException throw an error because message should be a string and not null …

This will fix #400