### PR TITLE
Update composer and tests to support php 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,27 @@ jobs:
       - name: Run tests
         run: ./vendor/bin/phpunit --testsuite Unit
 
+  build80:
+    name: Build PHP 8.0
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 10
+
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@2.1.0
+        with:
+          php-version: 8.0
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Download dependencies
+        run: composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
+
+      - name: Run tests
+        run: ./vendor/bin/phpunit --testsuite Unit
+
   integration:
     name: Integration tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.2', '7.3', '7.4', '8.0']
         sf_version: ['3.4.*', '4.4.*', '5.0.*']
 
     steps:
@@ -52,27 +52,6 @@ jobs:
       - name: Download dependencies
         env:
           SYMFONY_REQUIRE: ${{ matrix.sf_version }}
-        run: composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
-
-      - name: Run tests
-        run: ./vendor/bin/phpunit --testsuite Unit
-
-  build80:
-    name: Build PHP 8.0
-    runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 10
-
-    steps:
-      - name: Set up PHP
-        uses: shivammathur/setup-php@2.1.0
-        with:
-          php-version: 8.0
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Download dependencies
         run: composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@2.1.0
         with:
-          php-version: 7.3
+          php-version: 7.4
           tools: flex
 
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Run tests
         run: |
-          docker run --rm --net buzz-bridge -v "$PWD":/usr/src/myapp -w /usr/src/myapp -e BUZZ_TEST_SERVER=http://test-server/index.php tommymuehle/docker-alpine-php-nightly php vendor/bin/phpunit
+          docker run --rm --net buzz-bridge -v "$PWD":/usr/src/myapp -w /usr/src/myapp -e BUZZ_TEST_SERVER=http://test-server/index.php php:7.4-cli php vendor/bin/phpunit
 
   lowest:
     name: Lowest deps

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -42,6 +42,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Psalm
-        uses: docker://muglug/psalm-github-actions
+        uses: docker://vimeo/psalm-github-actions
         with:
           args: --no-progress --show-info=false --stats

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-fpm-stretch
+FROM php:7.4-fpm-buster
 
 # Install Nginx
 RUN apt-get update -qq && apt-get install -y --no-install-recommends -qq nginx

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^7.1 || ^8.0",
         "psr/http-message": "^1.0",
         "psr/http-client": "^1.0",
         "php-http/httplug": "^1.1 || ^2.0",
@@ -26,10 +26,10 @@
         "psr/http-factory": "^1.0"
     },
     "require-dev": {
-        "php-http/client-integration-tests": "^3.0.0",
+        "php-http/client-integration-tests": "^3.0",
         "nyholm/psr7": "^1.0",
         "psr/log": "^1.0",
-        "phpunit/phpunit": "7.5.20|9.4.1"
+        "phpunit/phpunit": "^7.5 || ^9.4"
     },
     "provide": {
         "php-http/client-implementation": "1.0",

--- a/composer.json
+++ b/composer.json
@@ -48,5 +48,8 @@
         "psr-4": {
             "Buzz\\Test\\": "tests"
         }
+    },
+    "conflict": {
+        "symfony/polyfill-php80": "*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^8.0",
         "psr/http-message": "^1.0",
         "psr/http-client": "^1.0",
         "php-http/httplug": "^1.1 || ^2.0",
@@ -26,10 +26,10 @@
         "psr/http-factory": "^1.0"
     },
     "require-dev": {
-        "php-http/client-integration-tests": "^2.0.1",
+        "php-http/client-integration-tests": "^3.0.0",
         "nyholm/psr7": "^1.0",
         "psr/log": "^1.0",
-        "phpunit/phpunit": "7.5.20"
+        "phpunit/phpunit": "7.5.20|9.4.1"
     },
     "provide": {
         "php-http/client-implementation": "1.0",

--- a/composer.json
+++ b/composer.json
@@ -48,8 +48,5 @@
         "psr-4": {
             "Buzz\\Test\\": "tests"
         }
-    },
-    "conflict": {
-        "symfony/polyfill-php80": "*"
     }
 }

--- a/lib/Client/AbstractClient.php
+++ b/lib/Client/AbstractClient.php
@@ -13,7 +13,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 abstract class AbstractClient
 {
     /**
-     * @var OptionsResolver
+     * @var OptionsResolver|null
      */
     private $optionsResolver;
 

--- a/lib/Client/MultiCurl.php
+++ b/lib/Client/MultiCurl.php
@@ -56,7 +56,13 @@ class MultiCurl extends AbstractCurl implements BatchClientInterface, BuzzClient
     {
         parent::__construct($responseFactory, $options);
 
-        if (\PHP_VERSION_ID < 70215 || \PHP_VERSION_ID === 70300 || \PHP_VERSION_ID === 70301 || !(CURL_VERSION_HTTP2 & curl_version()['features'])) {
+        if (
+            \PHP_VERSION_ID < 70215 ||
+            \PHP_VERSION_ID === 70300 ||
+            \PHP_VERSION_ID === 70301 ||
+            \PHP_VERSION_ID >= 80000 ||
+            !(CURL_VERSION_HTTP2 & curl_version()['features'])
+        ) {
             // Dont use HTTP/2 push when it's unsupported or buggy, see https://bugs.php.net/76675
             $this->serverPushSupported = false;
         }

--- a/tests/Integration/BaseIntegrationTest.php
+++ b/tests/Integration/BaseIntegrationTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 abstract class BaseIntegrationTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (getenv('BUZZ_TEST_SERVER')) {

--- a/tests/Integration/BuzzIntegrationTest.php
+++ b/tests/Integration/BuzzIntegrationTest.php
@@ -21,7 +21,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class BuzzIntegrationTest extends BaseIntegrationTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (empty($_SERVER['BUZZ_TEST_SERVER'])) {
@@ -125,7 +125,7 @@ class BuzzIntegrationTest extends BaseIntegrationTest
         $this->assertNotEmpty($response->getBody()->__toString(), 'Response from server should not be empty');
 
         $data = json_decode($response->getBody()->__toString(), true);
-        $this->assertInternalType('array', $data, $response->getBody()->__toString());
+        $this->assertIsArray($data, $response->getBody()->__toString());
         $this->assertArrayHasKey('SERVER', $data);
 
         $this->assertStringStartsWith('multipart/form-data', $data['SERVER']['CONTENT_TYPE']);
@@ -156,7 +156,7 @@ class BuzzIntegrationTest extends BaseIntegrationTest
         $this->assertNotEmpty($response->getBody()->__toString(), 'Response from server should not be empty');
 
         $data = json_decode($response->getBody()->__toString(), true);
-        $this->assertInternalType('array', $data, $response->getBody()->__toString());
+        $this->assertIsArray($data, $response->getBody()->__toString());
         $this->assertArrayHasKey('SERVER', $data);
 
         $this->assertStringStartsWith('multipart/form-data', $data['SERVER']['CONTENT_TYPE']);

--- a/tests/Integration/Httplug/BaseIntegrationTest.php
+++ b/tests/Integration/Httplug/BaseIntegrationTest.php
@@ -9,7 +9,7 @@ use Http\Client\Tests\PHPUnitUtility;
 
 abstract class BaseIntegrationTest extends HttpClientTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (false === PHPUnitUtility::getUri()) {

--- a/tests/Integration/Httplug/BrowserIntegrationTest.php
+++ b/tests/Integration/Httplug/BrowserIntegrationTest.php
@@ -7,10 +7,11 @@ namespace Buzz\Test\Integration\Httplug;
 use Buzz\Browser;
 use Buzz\Client\FileGetContents;
 use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Client\ClientInterface;
 
 class BrowserIntegrationTest extends BaseIntegrationTest
 {
-    protected function createHttpAdapter()
+    protected function createHttpAdapter(): ClientInterface
     {
         $client = new FileGetContents(new Psr17Factory(), []);
         $browser = new Browser($client, new Psr17Factory());

--- a/tests/Integration/Httplug/CurlIntegrationTest.php
+++ b/tests/Integration/Httplug/CurlIntegrationTest.php
@@ -6,10 +6,11 @@ namespace Buzz\Test\Integration\Httplug;
 
 use Buzz\Client\Curl;
 use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Client\ClientInterface;
 
 class CurlIntegrationTest extends BaseIntegrationTest
 {
-    protected function createHttpAdapter()
+    protected function createHttpAdapter(): ClientInterface
     {
         return new Curl(new Psr17Factory(), []);
     }

--- a/tests/Integration/Httplug/FileGetContentsIntegrationTest.php
+++ b/tests/Integration/Httplug/FileGetContentsIntegrationTest.php
@@ -6,10 +6,11 @@ namespace Buzz\Test\Integration\Httplug;
 
 use Buzz\Client\FileGetContents;
 use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Client\ClientInterface;
 
 class FileGetContentsIntegrationTest extends BaseIntegrationTest
 {
-    protected function createHttpAdapter()
+    protected function createHttpAdapter(): ClientInterface
     {
         return new FileGetContents(new Psr17Factory(), []);
     }

--- a/tests/Integration/Httplug/MultiCurlIntegrationTest.php
+++ b/tests/Integration/Httplug/MultiCurlIntegrationTest.php
@@ -6,10 +6,11 @@ namespace Buzz\Test\Integration\Httplug;
 
 use Buzz\Client\MultiCurl;
 use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Client\ClientInterface;
 
 class MultiCurlIntegrationTest extends BaseIntegrationTest
 {
-    protected function createHttpAdapter()
+    protected function createHttpAdapter(): ClientInterface
     {
         return new MultiCurl(new Psr17Factory(), []);
     }

--- a/tests/Integration/MultiCurlServerPushTest.php
+++ b/tests/Integration/MultiCurlServerPushTest.php
@@ -10,7 +10,7 @@ use Nyholm\Psr7\Request;
 
 class MultiCurlServerPushTest extends BaseIntegrationTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (\PHP_VERSION_ID < 70400 || curl_version()['version_number'] < 472065) {

--- a/tests/Integration/MultiCurlServerPushTest.php
+++ b/tests/Integration/MultiCurlServerPushTest.php
@@ -13,7 +13,7 @@ class MultiCurlServerPushTest extends BaseIntegrationTest
     protected function setUp(): void
     {
         parent::setUp();
-        if (\PHP_VERSION_ID < 70400 || curl_version()['version_number'] < 472065) {
+        if (\PHP_VERSION_ID < 70400 || \PHP_VERSION_ID >= 80000 || curl_version()['version_number'] < 472065) {
             $this->markTestSkipped('This environment does not support server push');
         }
     }

--- a/tests/Integration/MultiCurlTest.php
+++ b/tests/Integration/MultiCurlTest.php
@@ -11,7 +11,7 @@ use Nyholm\Psr7\Request;
 
 class MultiCurlTest extends BaseIntegrationTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (empty($_SERVER['BUZZ_TEST_SERVER'])) {

--- a/tests/Unit/BrowserTest.php
+++ b/tests/Unit/BrowserTest.php
@@ -20,7 +20,7 @@ class BrowserTest extends TestCase
     /** @var Browser */
     private $browser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->client = $this->getMockBuilder('Buzz\Client\Curl')
             ->disableOriginalConstructor()
@@ -112,7 +112,7 @@ class BrowserTest extends TestCase
             $regex = substr($requestBody, 5);
             $regex = str_replace("\n", "\r\n", $regex);
 
-            return preg_match($regex, $input);
+            return false !== preg_match($regex, $input);
         };
 
         $browser = $this->getMockBuilder(Browser::class)

--- a/tests/Unit/Middleware/History/JournalTest.php
+++ b/tests/Unit/Middleware/History/JournalTest.php
@@ -23,7 +23,7 @@ class JournalTest extends TestCase
 
     protected $response3;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->request1 = new Request('GET', '/r1', [], 'request1');
         $this->request2 = new Request('GET', '/r2', [], 'request2');
@@ -33,7 +33,7 @@ class JournalTest extends TestCase
         $this->response3 = new Response(200, [], 'response3');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->request1 = null;
         $this->request2 = null;

--- a/tests/Unit/Middleware/HistoryMiddlewareTest.php
+++ b/tests/Unit/Middleware/HistoryMiddlewareTest.php
@@ -16,7 +16,7 @@ class HistoryMiddlewareTest extends TestCase
     /** @var HistoryMiddleware */
     private $middleware;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->journal = $this->getMockBuilder('Buzz\Middleware\History\Journal')
             ->disableOriginalConstructor()

--- a/tests/Unit/Middleware/LoggerMiddlewareTest.php
+++ b/tests/Unit/Middleware/LoggerMiddlewareTest.php
@@ -19,7 +19,8 @@ class LoggerMiddlewareTest extends TestCase
 
         // TODO Use PSR3 logger
         $logger = new CallbackLogger(function ($level, $message, array $context) use ($that) {
-            $that->assertRegExp('~^Sent "GET http://google.com/" in \d+ms$~', $message);
+            $method = method_exists($that, 'assertRegExp') ? 'assertRegExp' : 'assertMatchesRegularExpression';
+            $that->$method('~^Sent "GET http://google.com/" in \d+ms$~', $message);
         });
 
         $request = new Request('GET', 'http://google.com/');

--- a/tests/Unit/Middleware/LoggerMiddlewareTest.php
+++ b/tests/Unit/Middleware/LoggerMiddlewareTest.php
@@ -19,8 +19,14 @@ class LoggerMiddlewareTest extends TestCase
 
         // TODO Use PSR3 logger
         $logger = new CallbackLogger(function ($level, $message, array $context) use ($that) {
-            $method = method_exists($that, 'assertRegExp') ? 'assertRegExp' : 'assertMatchesRegularExpression';
-            $that->$method('~^Sent "GET http://google.com/" in \d+ms$~', $message);
+            $pattern = '~^Sent "GET http://google.com/" in \d+ms$~';
+            if (method_exists($this, 'assertMatchesRegularExpression')) {
+                $that->assertMatchesRegularExpression($pattern, $message);
+
+                return;
+            }
+            // phpunit 7 compatibility
+            $that->assertRegExp($pattern, $message);
         });
 
         $request = new Request('GET', 'http://google.com/');

--- a/tests/Unit/Middleware/WsseAuthMiddlewareTest.php
+++ b/tests/Unit/Middleware/WsseAuthMiddlewareTest.php
@@ -22,6 +22,7 @@ class WsseAuthMiddlewareTest extends TestCase
 
         $this->assertEquals('WSSE profile="UsernameToken"', $newRequest->getHeaderLine('Authorization'));
         $wsse = $newRequest->getHeaderLine('X-WSSE');
-        $this->assertRegExp('|UsernameToken Username="foo", PasswordDigest=".+?", Nonce=".+?", Created=".+?"|', $wsse);
+        $method = method_exists($this, 'assertRegExp') ? 'assertRegExp' : 'assertMatchesRegularExpression';
+        $this->$method('|UsernameToken Username="foo", PasswordDigest=".+?", Nonce=".+?", Created=".+?"|', $wsse);
     }
 }

--- a/tests/Unit/Middleware/WsseAuthMiddlewareTest.php
+++ b/tests/Unit/Middleware/WsseAuthMiddlewareTest.php
@@ -22,7 +22,13 @@ class WsseAuthMiddlewareTest extends TestCase
 
         $this->assertEquals('WSSE profile="UsernameToken"', $newRequest->getHeaderLine('Authorization'));
         $wsse = $newRequest->getHeaderLine('X-WSSE');
-        $method = method_exists($this, 'assertRegExp') ? 'assertRegExp' : 'assertMatchesRegularExpression';
-        $this->$method('|UsernameToken Username="foo", PasswordDigest=".+?", Nonce=".+?", Created=".+?"|', $wsse);
+        $pattern = '|UsernameToken Username="foo", PasswordDigest=".+?", Nonce=".+?", Created=".+?"|';
+        if (method_exists($this, 'assertMatchesRegularExpression')) {
+            $this->assertMatchesRegularExpression($pattern, $wsse);
+
+            return;
+        }
+        // phpunit 7 compatibility
+        $this->assertRegExp($pattern, $wsse);
     }
 }


### PR DESCRIPTION
This is the smallest change I could make and make the tests pass and work on both php 7.1 and php 8.0.0-rc1

I haven't update the `ci.yml` due to not being familiar with that setup