### PR TITLE
Allow installation of `symfony/options-resolver:^6.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "psr/http-message": "^1.0",
         "psr/http-client": "^1.0",
         "php-http/httplug": "^1.1 || ^2.0",
-        "symfony/options-resolver": "^3.4 || ^4.0 || ^5.0",
+        "symfony/options-resolver": "^3.4 || ^4.0 || ^5.0 || ^6.0",
         "psr/http-factory": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Similar to #408, this PR simply allows version 6.x of `symfony/options-resolver` to be installed.

The only listed change for version 6.0 is the [removal of `OptionsResolverIntrospector::getDeprecationMessage()`](https://github.com/symfony/options-resolver/blob/6.0/CHANGELOG.md#60), which is [not used by this project](https://github.com/kriswallsmith/Buzz/search?q=getDeprecationMessage), so `composer.json` is the only thing that needs to be changed.