### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/Client/BuzzClientInterface.php
+++ b/lib/Client/BuzzClientInterface.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Buzz\Client;
 
-use Http\Client\HttpClient;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -12,7 +11,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-interface BuzzClientInterface extends ClientInterface, HttpClient
+interface BuzzClientInterface extends ClientInterface
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
The "Buzz\Client\BuzzClientInterface" interface extends "Http\Client\HttpClient" that is deprecated since version 2.4, use Psr\Http\Client\ClientInterface instead; see https://www.php-fig.org/psr/psr-18/.