### PR TITLE
Add support for psr/http-message 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.1 || ^2.0",
         "psr/http-client": "^1.0",
         "php-http/httplug": "^1.1 || ^2.0",
         "symfony/options-resolver": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0",


### PR DESCRIPTION
This PR bumps the `psr/http-message` constraint from `^1.0` to `^1.1 || ^2.0`.