### PR TITLE
Add Symfony 8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,22 @@ jobs:
       matrix:
         php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
         sf_version: ['3.4.*', '4.4.*', '5.0.*', '6.4.*', '7.4.*', '8.0.*']
+        exclude:
+          # Symfony 8.0 requires PHP 8.4+
+          - php: '7.2'
+            sf_version: '8.0.*'
+          - php: '7.3'
+            sf_version: '8.0.*'
+          - php: '7.4'
+            sf_version: '8.0.*'
+          - php: '8.0'
+            sf_version: '8.0.*'
+          - php: '8.1'
+            sf_version: '8.0.*'
+          - php: '8.2'
+            sf_version: '8.0.*'
+          - php: '8.3'
+            sf_version: '8.0.*'
 
     steps:
       - name: Set up PHP


### PR DESCRIPTION
 This PR adds support for Symfony 8 by bumping the `symfony/options-resolver` constraint to include `^8.0`.